### PR TITLE
feat: Daily sales reports, category CRUD, order persistence, UI unifo…

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -5,6 +5,7 @@ from api.orders import router as orders_router
 from api.dashboards import router as dashboards_router
 from api.users import router as users_router
 from api.menu import menu_router, category_router
+from api.reports import router as reports_router
 
 api_router = APIRouter()
 
@@ -15,3 +16,4 @@ api_router.include_router(dashboards_router)
 api_router.include_router(users_router)
 api_router.include_router(menu_router)
 api_router.include_router(category_router)
+api_router.include_router(reports_router)

--- a/backend/api/orders.py
+++ b/backend/api/orders.py
@@ -2,8 +2,12 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
 from typing import List, Optional
+from sqlmodel import Session
+from db.session import get_session
 from core.security import get_current_guest
 from models.user import TokenData
+from models.order import Order
+from models.order_item import OrderItem
 from core.websocket_manager import manager
 from core.ai import run_ai_kds_optimizer, run_ai_safety_agent
 
@@ -15,6 +19,7 @@ MAX_NOTES_LENGTH = 500
 
 class OrderItemPayload(BaseModel):
     """Un singur produs din comandă."""
+    menu_item_id: Optional[int] = Field(default=None, ge=1)
     name: str = Field(min_length=1, max_length=200)
     quantity: int = Field(ge=1, le=99)
     prep_time: int = Field(ge=0, le=120)
@@ -42,7 +47,8 @@ class OrderCreatePayload(BaseModel):
 @router.post("")
 async def create_order(
     order: OrderCreatePayload,
-    guest: TokenData = Depends(get_current_guest)
+    guest: TokenData = Depends(get_current_guest),
+    session: Session = Depends(get_session)
 ):
     """
     Apelat de Client (Guest). 
@@ -60,6 +66,26 @@ async def create_order(
     safety_priority = run_ai_safety_agent(order.notes or "")
     cooking_advice = run_ai_kds_optimizer([item.model_dump() for item in order.items])
 
+    # 2. Persistăm comanda în baza de date
+    db_order = Order(
+        table_id=table_id,
+        total_price=order.total or 0.0,
+        special_requests=order.notes,
+    )
+    session.add(db_order)
+    session.flush()  # obținem db_order.id fără commit
+
+    for item in order.items:
+        db_item = OrderItem(
+            order_id=db_order.id,
+            menu_item_id=item.menu_item_id or 0,
+            quantity=item.quantity,
+            special_instructions=None,
+        )
+        session.add(db_item)
+
+    session.commit()
+
     # Suprascriem table_number cu valoarea de încredere din JWT
     sanitized_order = order.model_dump()
     sanitized_order["table_number"] = table_id
@@ -73,13 +99,13 @@ async def create_order(
         "data": sanitized_order
     }
     
-    # 2. Notificăm Bucătăria (KDS) în timp real
+    # 3. Notificăm Bucătăria (KDS) în timp real
     await manager.broadcast_to_role("chef", payload)
     
-    # 3. Notificăm și Chelnerul că s-a ocupat o masă 
+    # 4. Notificăm și Chelnerul că s-a ocupat o masă 
     await manager.broadcast_to_role("waiter", {
         "event": "TABLE_OCCUPIED",
         "table": table_id
     })
 
-    return {"status": "Processed by AI and sent to KDS", "ai_safety": safety_priority, "table_id": table_id}
+    return {"status": "Processed by AI and sent to KDS", "ai_safety": safety_priority, "table_id": table_id, "order_id": db_order.id}

--- a/backend/api/reports.py
+++ b/backend/api/reports.py
@@ -1,0 +1,111 @@
+from datetime import date, datetime, timezone, timedelta
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlmodel import Session, select, func
+from sqlalchemy import cast, Date
+
+from db.session import get_session
+from models.user import User
+from models.order import Order
+from models.order_item import OrderItem
+from models.menu_item import MenuItem
+from core.security import require_role
+
+router = APIRouter(prefix="/reports", tags=["Reports"])
+
+
+class TopItemRead(BaseModel):
+    name: str
+    quantity_sold: int
+
+
+class RevenueByDay(BaseModel):
+    date: str
+    revenue: float
+
+
+class RangeReportRead(BaseModel):
+    start_date: str
+    end_date: str
+    total_revenue: float
+    total_orders: int
+    average_order_value: float
+    top_items: List[TopItemRead]
+    revenue_by_day: List[RevenueByDay]
+
+
+@router.get("/range", response_model=RangeReportRead)
+async def get_range_report(
+    start_date: Optional[str] = Query(default=None),
+    end_date: Optional[str] = Query(default=None),
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Manager"]))
+):
+    """Raport pe o perioadă — doar Manager."""
+    today = datetime.now(timezone.utc).date()
+
+    if start_date:
+        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+    else:
+        start = today
+
+    if end_date:
+        end = datetime.strptime(end_date, "%Y-%m-%d").date()
+    else:
+        end = today
+
+    if start > end:
+        start, end = end, start
+
+    start_dt = datetime(start.year, start.month, start.day, tzinfo=timezone.utc)
+    end_dt = datetime(end.year, end.month, end.day, 23, 59, 59, tzinfo=timezone.utc)
+
+    date_range = cast(Order.created_at, Date).between(start, end)
+
+    # Total revenue
+    revenue_stmt = select(func.coalesce(func.sum(Order.total_price), 0)).where(date_range)
+    total_revenue = float(session.exec(revenue_stmt).one())
+
+    # Total orders
+    count_stmt = select(func.count()).where(date_range)
+    total_orders = int(session.exec(count_stmt).one())
+
+    average_order_value = round(total_revenue / total_orders, 2) if total_orders > 0 else 0.0
+
+    # Top 3 items
+    top_stmt = (
+        select(MenuItem.name, func.sum(OrderItem.quantity).label("qty"))
+        .join(OrderItem, MenuItem.id == OrderItem.menu_item_id)
+        .join(Order, OrderItem.order_id == Order.id)
+        .where(date_range)
+        .group_by(MenuItem.name)
+        .order_by(func.sum(OrderItem.quantity).desc())
+        .limit(3)
+    )
+    top_rows = session.exec(top_stmt).all()
+    top_items = [TopItemRead(name=str(row[0]), quantity_sold=int(row[1])) for row in top_rows]
+
+    # Revenue by day
+    day_stmt = (
+        select(
+            cast(Order.created_at, Date).label("day"),
+            func.coalesce(func.sum(Order.total_price), 0).label("revenue")
+        )
+        .where(date_range)
+        .group_by(cast(Order.created_at, Date))
+        .order_by(cast(Order.created_at, Date))
+    )
+    day_rows = session.exec(day_stmt).all()
+    revenue_by_day = [RevenueByDay(date=str(row[0]), revenue=float(row[1])) for row in day_rows]
+
+    return RangeReportRead(
+        start_date=start.isoformat(),
+        end_date=end.isoformat(),
+        total_revenue=total_revenue,
+        total_orders=total_orders,
+        average_order_value=average_order_value,
+        top_items=top_items,
+        revenue_by_day=revenue_by_day,
+    )

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -2,3 +2,5 @@
 from .user import User, UserRole, Token, TokenData
 from .menu_item import MenuItem
 from .category import Category
+from .order import Order, OrderStatus
+from .order_item import OrderItem

--- a/frontend/app/chef/ClientPage.tsx
+++ b/frontend/app/chef/ClientPage.tsx
@@ -41,7 +41,7 @@ function ChefContent() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-900 p-8 text-white">
+    <div className="min-h-screen bg-slate-950 p-8 text-white">
       <header className="flex justify-between items-center mb-8">
         <h1 className="text-4xl font-black text-orange-500 tracking-tight">KITCHEN DISPLAY SYSTEM</h1>
         <div className="flex items-center gap-6">

--- a/frontend/app/customer/page.tsx
+++ b/frontend/app/customer/page.tsx
@@ -175,7 +175,7 @@ function CustomerContent() {
       const orderPayload = {
         id: Math.floor(Math.random() * 1000),
         table_number: tableId,
-        items: cart.map(item => ({ name: item.name, quantity: item.quantity, prep_time: 15 })),
+        items: cart.map(item => ({ menu_item_id: item.productId, name: item.name, quantity: item.quantity, prep_time: 15 })),
         notes: cart.map(item => item.notes).filter(n => n).join(" | "),
         total: cartTotal
       };
@@ -333,7 +333,7 @@ function CustomerContent() {
                               <div className="grid gap-4 py-6">
                                 <textarea
                                   placeholder="Note speciale (alergii, preferințe)..."
-                                  className="w-full bg-slate-950 text-white rounded-xl p-5 min-h-[120px] border border-slate-700 focus:border-violet-500 outline-none"
+                                  className="w-full bg-slate-950 text-white rounded-xl p-5 min-h-[120px] border border-slate-700 focus:border-violet-500 focus:ring-1 focus:ring-violet-500/30 outline-none"
                                   value={instructions}
                                   onChange={(e) => setInstructions(e.target.value)}
                                 />
@@ -393,7 +393,7 @@ function CustomerContent() {
                           <div className="grid gap-4 py-6">
                             <textarea
                               placeholder="Note speciale (alergii, preferințe)..."
-                              className="w-full bg-slate-950 text-white rounded-xl p-5 min-h-[120px] border border-slate-700 focus:border-violet-500 outline-none"
+                              className="w-full bg-slate-950 text-white rounded-xl p-5 min-h-[120px] border border-slate-700 focus:border-violet-500 focus:ring-1 focus:ring-violet-500/30 outline-none"
                               value={instructions}
                               onChange={(e) => setInstructions(e.target.value)}
                             />
@@ -452,7 +452,7 @@ function CustomerContent() {
                     </div>
                   ))}
                   <div className="border-t border-slate-700 mt-2 pt-4 flex justify-between items-center">
-                    <span className="text-lg font-medium text-slate-300">Total:</span>
+                    <span className="text-lg font-medium text-slate-200">Total:</span>
                     <span className="text-2xl font-black text-white">{cartTotal.toFixed(2)} RON</span>
                   </div>
                 </div>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} dark h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">{children}</body>
     </html>

--- a/frontend/app/manager/ClientPage.tsx
+++ b/frontend/app/manager/ClientPage.tsx
@@ -8,6 +8,7 @@ import UserProfileMenu from "@/components/ui/UserProfileMenu";
 import ClientRoleGuard from "@/components/ClientRoleGuard";
 import { apiRequest } from "@/lib/api";
 import { Pencil, Trash2 } from "lucide-react";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 
@@ -70,10 +71,15 @@ export default function ManagerPage() {
 
   const [toast, setToast] = useState<{ message: string; type: "success" | "error"; visible: boolean } | null>(null);
 
-  const [activeTab, setActiveTab] = useState<"products" | "categories">("products");
+  const [activeTab, setActiveTab] = useState<"products" | "categories" | "reports">("products");
   const [categoryForm, setCategoryForm] = useState({ name: "", description: "" });
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
+
+  const [reportStart, setReportStart] = useState(new Date().toISOString().slice(0, 10));
+  const [reportEnd, setReportEnd] = useState(new Date().toISOString().slice(0, 10));
+  const [reportData, setReportData] = useState<any>(null);
+  const [reportLoading, setReportLoading] = useState(false);
 
   const showToast = useCallback((message: string, type: "success" | "error" = "success") => {
     setToast({ message, type, visible: true });
@@ -307,6 +313,23 @@ export default function ManagerPage() {
     }
   }
 
+  const fetchReport = useCallback(async (start: string, end: string) => {
+    setReportLoading(true);
+    try {
+      const res = await apiRequest(`/reports/range?start_date=${start}&end_date=${end}`);
+      if (!res.ok) throw new Error("Eroare la încărcarea raportului");
+      setReportData(await res.json());
+    } catch {
+      // ignore — report is optional
+    } finally {
+      setReportLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchReport(reportStart, reportEnd);
+  }, [reportStart, reportEnd, fetchReport]);
+
   return (
     <ClientRoleGuard role="Manager" theme="dark" spinnerColor="border-green-500">
       <div className="min-h-screen bg-slate-950 text-slate-100 p-8">
@@ -338,6 +361,16 @@ export default function ManagerPage() {
               >
                 Categorii
               </button>
+              <button
+                onClick={() => setActiveTab("reports")}
+                className={`px-4 py-1.5 rounded-md text-sm font-semibold transition-colors ${
+                  activeTab === "reports"
+                    ? "bg-green-600 text-white"
+                    : "text-slate-400 hover:text-white"
+                }`}
+              >
+                Rapoarte
+              </button>
             </div>
           </div>
         </header>
@@ -349,8 +382,8 @@ export default function ManagerPage() {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Încasări Zilnice</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-green-400">1,250.50 RON</p></CardContent></Card>
-          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Comenzi Totale</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-blue-400">24</p></CardContent></Card>
+          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Încasări Zilnice</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-green-400">{reportData ? `${reportData.total_revenue.toFixed(2)} RON` : "—"}</p></CardContent></Card>
+          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Comenzi totale astăzi</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-blue-400">{reportData ? reportData.total_orders : "—"}</p></CardContent></Card>
           <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Produse în Meniu</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-green-400">{menuItems.length}</p></CardContent></Card>
         </div>
 
@@ -384,12 +417,12 @@ export default function ManagerPage() {
                   </div>
                   {item.description && <p className="text-slate-400 text-sm line-clamp-2">{item.description}</p>}
                   <div className="flex items-center gap-2 flex-wrap">
-                    <span className="text-xs bg-slate-800 px-2 py-0.5 rounded-full text-slate-300">{item.category}</span>
+                    <span className="text-xs bg-slate-800 px-2 py-0.5 rounded-full text-slate-200">{item.category}</span>
                     <button onClick={() => handleToggleAvailability(item)} className={`text-xs px-2 py-0.5 rounded-full font-medium transition-colors ${item.is_available ? "bg-green-900/50 text-green-300 hover:bg-green-900" : "bg-red-900/50 text-red-300 hover:bg-red-900"}`}>{item.is_available ? "Disponibil" : "Indisponibil"}</button>
                   </div>
                   <div className="flex gap-2 pt-1">
-                    <Button variant="outline" size="sm" className="flex-1 border-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white" onClick={() => handleEdit(item)}><Pencil size={14} className="mr-1.5" />Editează</Button>
-                    <Button variant="outline" size="sm" className="border-red-900/50 text-red-400 hover:bg-red-950 hover:text-red-300" onClick={() => handleDelete(item.id)}><Trash2 size={14} /></Button>
+                    <Button variant="outline" size="sm" className="flex-1 border-slate-600 text-slate-200 hover:bg-slate-700 hover:text-white" onClick={() => handleEdit(item)}><Pencil size={14} className="mr-1.5" />Editează</Button>
+                    <Button variant="outline" size="sm" className="border-red-800/50 text-red-400 hover:bg-red-950 hover:text-red-300" onClick={() => handleDelete(item.id)}><Trash2 size={14} /></Button>
                   </div>
                 </CardContent>
               </Card>
@@ -416,7 +449,7 @@ export default function ManagerPage() {
               <div className="flex items-center gap-3"><span className="text-sm text-slate-400">Disponibil în meniu:</span><button type="button" onClick={() => setIsFormAvailable(!isFormAvailable)} className={`relative w-11 h-6 rounded-full transition-colors ${isFormAvailable ? "bg-green-600" : "bg-slate-600"}`}><span className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${isFormAvailable ? "translate-x-5" : ""}`} /></button></div>
             </div>
             <DialogFooter>
-              <Button variant="outline" className="border-slate-700 text-slate-300 hover:bg-slate-800" onClick={() => { setIsModalOpen(false); resetForm(); }}>Anulează</Button>
+              <Button variant="outline" className="border-slate-600 text-slate-200 hover:bg-slate-700" onClick={() => { setIsModalOpen(false); resetForm(); }}>Anulează</Button>
               <Button className="bg-green-600 hover:bg-green-500 font-bold" onClick={handleSave} disabled={saving}>{saving ? "Se salvează..." : editingItem ? "Salvează Modificări" : "Adaugă Produs"}</Button>
             </DialogFooter>
           </DialogContent>
@@ -447,7 +480,7 @@ export default function ManagerPage() {
                       {cat.description && <p className="text-slate-400">{cat.description}</p>}
                     </div>
                     <div className="flex gap-2">
-                      <Button variant="outline" size="sm" className="border-slate-700 text-slate-300 hover:bg-slate-800" onClick={() => handleEditCategory(cat)}>
+                      <Button variant="outline" size="sm" className="border-slate-600 text-slate-200 hover:bg-slate-700" onClick={() => handleEditCategory(cat)}>
                         <Pencil size={14} className="mr-1" /> Editează
                       </Button>
                       <Button variant="outline" size="sm" className="border-red-900/50 text-red-400 hover:bg-red-950" onClick={() => handleDeleteCategory(cat)}>
@@ -490,7 +523,7 @@ export default function ManagerPage() {
               </div>
             </div>
             <DialogFooter>
-              <Button variant="outline" className="border-slate-700 text-slate-300 hover:bg-slate-800" onClick={() => { setIsCategoryModalOpen(false); setEditingCategory(null); }}>
+              <Button variant="outline" className="border-slate-600 text-slate-200 hover:bg-slate-700" onClick={() => { setIsCategoryModalOpen(false); setEditingCategory(null); }}>
                 Anulează
               </Button>
               <Button className="bg-green-600 hover:bg-green-500 font-bold" onClick={handleSaveCategory} disabled={saving}>
@@ -499,6 +532,68 @@ export default function ManagerPage() {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+        </>
+        )}
+
+        {activeTab === "reports" && (
+        <>
+        <div className="flex flex-col gap-4 mb-6">
+          <div className="flex justify-between items-center">
+            <h2 className="text-2xl font-bold text-white">Rapoarte</h2>
+            <div className="flex gap-2">
+              <button onClick={() => { const d = new Date(); setReportStart(d.toISOString().slice(0,10)); setReportEnd(d.toISOString().slice(0,10)); }} className="px-3 py-1 rounded text-xs font-semibold bg-slate-800 text-slate-400 hover:bg-slate-700">Azi</button>
+              <button onClick={() => { const e = new Date(); const s = new Date(); s.setDate(e.getDate()-7); setReportStart(s.toISOString().slice(0,10)); setReportEnd(e.toISOString().slice(0,10)); }} className="px-3 py-1 rounded text-xs font-semibold bg-slate-800 text-slate-400 hover:bg-slate-700">7 zile</button>
+              <button onClick={() => { const e = new Date(); const s = new Date(); s.setDate(e.getDate()-30); setReportStart(s.toISOString().slice(0,10)); setReportEnd(e.toISOString().slice(0,10)); }} className="px-3 py-1 rounded text-xs font-semibold bg-slate-800 text-slate-400 hover:bg-slate-700">30 zile</button>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 text-sm text-slate-400">
+            <span>De la:</span>
+            <input type="date" value={reportStart} onChange={(e) => setReportStart(e.target.value)} className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-white focus:border-green-500 outline-none text-sm" />
+            <span>Până la:</span>
+            <input type="date" value={reportEnd} onChange={(e) => setReportEnd(e.target.value)} className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-white focus:border-green-500 outline-none text-sm" />
+          </div>
+        </div>
+        {reportLoading && <div className="text-center py-12 text-slate-400 text-lg">Se încarcă raportul...</div>}
+        {!reportLoading && reportData && (
+          <>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
+            <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Încasări Totale</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-green-400">{reportData.total_revenue.toFixed(2)} RON</p></CardContent></Card>
+            <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Comenzi Totale</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-blue-400">{reportData.total_orders}</p></CardContent></Card>
+            <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Valoare Medie</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-green-400">{reportData.average_order_value.toFixed(2)} RON</p></CardContent></Card>
+          </div>
+          {reportData.revenue_by_day.length > 0 && (
+            <Card className="bg-slate-900 border-slate-800 mb-10">
+              <CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Încasări pe Zi</CardTitle></CardHeader>
+              <CardContent>
+                <ResponsiveContainer width="100%" height={300}>
+                  <BarChart data={reportData.revenue_by_day}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                    <XAxis dataKey="date" stroke="#94a3b8" tick={{ fill: "#94a3b8" }} tickFormatter={(d: string) => d.slice(5)} />
+                    <YAxis stroke="#94a3b8" tick={{ fill: "#94a3b8" }} tickFormatter={(v: number) => `${v} RON`} />
+                    <Tooltip contentStyle={{ backgroundColor: "#1e293b", border: "1px solid #334155", borderRadius: "8px", color: "#e2e8f0" }} labelStyle={{ color: "#94a3b8" }} />
+                    <Bar dataKey="revenue" fill="#22c55e" radius={[4, 4, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+          )}
+          {reportData.top_items.length > 0 && (
+            <Card className="bg-slate-900 border-slate-800">
+              <CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Top 3 Produse</CardTitle></CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  {reportData.top_items.map((item: any, i: number) => (
+                    <div key={item.name} className="flex justify-between items-center bg-slate-800 p-3 rounded-lg">
+                      <div className="flex items-center gap-3"><span className="text-2xl font-black text-slate-500">#{i + 1}</span><span className="text-white font-medium">{item.name}</span></div>
+                      <span className="text-green-400 font-bold">{item.quantity_sold} vândute</span>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+          </>
+        )}
         </>
         )}
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "recharts": "^2.15.4",
         "shadcn": "^4.3.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -2341,6 +2342,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3839,8 +3903,128 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3939,6 +4123,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -4085,6 +4275,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dotenv": {
@@ -4820,6 +5020,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -4933,6 +5139,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -5701,6 +5916,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -6781,6 +7005,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6832,7 +7062,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7814,7 +8043,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -7929,8 +8157,38 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
     },
     "node_modules/recast": {
       "version": "0.23.11",
@@ -7947,6 +8205,44 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -9456,6 +9752,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "recharts": "^2.15.4",
     "shadcn": "^4.3.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"


### PR DESCRIPTION
…rmity

Backend:
- Add PUT/DELETE endpoints for categories (Manager-only, with integrity check)
- Add GET /api/reports/range with configurable start/end date
- Persist Order + OrderItem to database in create_order endpoint
- Add menu_item_id to OrderItemPayload schema
- Export Order, OrderItem, OrderStatus from models

Frontend - Manager Dashboard:
- Category management tab (add/edit/delete categories with modal)
- Reports tab with date range picker (quick-select: today, 7d, 30d)
- Real-time metric cards (revenue, orders, avg order value)
- Daily revenue bar chart (recharts) + Top 3 best-sellers
- Dynamic stats cards in Products tab (replaces hardcoded values)

Frontend - Customer:
- Public menu route (/menu) with category filter + grouping
- API-fetched menu (removes MOCK_MENU)
- Alert() replaced with toast notifications
- menu_item_id included in checkout payload

Frontend - Navigation:
- BfcacheReload component to prevent infinite spinner on back/forward
- ClientRoleGuard layer simplification

Frontend - UI Uniformity:
- Button contrast: text-slate-300 → text-slate-200 on outline buttons
- Chef dark bg: bg-slate-900 → bg-slate-950
- Input focus ring: added focus:ring-1 across pages
- Category badge contrast: text-slate-300 → text-slate-200
- Cart total label contrast: text-slate-300 → text-slate-200