### PR TITLE
feat(ai): manager insights & menu agents + harden customer chat agent

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -7,6 +7,7 @@ from api.users import router as users_router
 from api.menu import menu_router, category_router
 from api.reports import router as reports_router
 from api.recommendations import router as recommendations_router
+from api.insights import router as insights_router
 
 api_router = APIRouter()
 
@@ -19,3 +20,4 @@ api_router.include_router(menu_router)
 api_router.include_router(category_router)
 api_router.include_router(reports_router)
 api_router.include_router(recommendations_router)
+api_router.include_router(insights_router)

--- a/backend/api/insights.py
+++ b/backend/api/insights.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, Depends
+from sqlmodel import Session, select
+from typing import Optional, List
+from pydantic import BaseModel
+from uuid import uuid4
+
+from db.session import get_session
+from models.user import User
+from models.menu_item import MenuItem
+from models.category import Category
+from core.security import require_role
+from core.ai import run_manager_insights_agent, clear_insights_session
+from api.reports import build_range_report
+
+router = APIRouter(prefix="/insights", tags=["Insights"])
+
+
+class InsightsChatRequest(BaseModel):
+    message: str
+    session_id: Optional[str] = None  # Null pentru o conversație nouă
+    start_date: Optional[str] = None  # YYYY-MM-DD; lipsă → ziua curentă
+    end_date: Optional[str] = None
+
+
+class ClearInsightsRequest(BaseModel):
+    session_id: str
+
+
+class InsightsChatResponse(BaseModel):
+    response_text: str
+    insights: List[str]
+    follow_up_question: Optional[str] = None
+    session_id: str
+    agent: str
+
+
+@router.post("/chat", response_model=InsightsChatResponse)
+async def insights_chat(
+    request: InsightsChatRequest,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Manager"])),
+):
+    """
+    Chat cu agentul AI de analiză pentru manager.
+    Analizează raportul de vânzări din perioada selectată și răspunde în limbaj natural.
+    """
+    session_id = request.session_id or str(uuid4())
+
+    report = build_range_report(session, request.start_date, request.end_date)
+
+    # Prețurile curente din meniu — ca agentul să poată propune prețuri concrete
+    # (ex: happy hour) pornind de la valoarea reală, nu inventată.
+    menu_rows = session.exec(
+        select(MenuItem.name, MenuItem.price, MenuItem.is_available, Category.name)
+        .join(Category, MenuItem.category_id == Category.id)
+        .order_by(Category.name, MenuItem.name)
+    ).all()
+    menu_items = [
+        {"name": row[0], "price": row[1], "is_available": row[2], "category": row[3]}
+        for row in menu_rows
+    ]
+
+    response = await run_manager_insights_agent(
+        message=request.message,
+        session_id=session_id,
+        report_data=report.model_dump(),
+        menu_items=menu_items,
+    )
+
+    return InsightsChatResponse(**response)
+
+
+@router.post("/chat/clear")
+async def clear_insights_chat(
+    request: ClearInsightsRequest,
+    current_user: User = Depends(require_role(["Manager"])),
+):
+    """Șterge sesiunea de chat de insights."""
+    clear_insights_session(request.session_id)
+    return {"status": "cleared"}

--- a/backend/api/menu.py
+++ b/backend/api/menu.py
@@ -10,6 +10,7 @@ from models.user import User
 from models.menu_item import MenuItem
 from models.category import Category
 from core.security import require_role
+from core.ai import run_menu_content_agent
 
 menu_router = APIRouter(prefix="/menu", tags=["Menu"])
 category_router = APIRouter(prefix="/categories", tags=["Categories"])
@@ -53,6 +54,31 @@ class MenuItemRead(BaseModel):
     dietary_tags: Optional[str] = None
 
     model_config = {"from_attributes": True}
+
+
+class MenuContentRequest(BaseModel):
+    name: str = Field(min_length=2, max_length=100)
+    ingredients: Optional[str] = Field(default=None, max_length=1000)
+    price_hint: Optional[float] = Field(default=None, gt=0.0)
+
+
+class SuggestedCategory(BaseModel):
+    name: str
+    is_new: bool
+
+
+class PriceBand(BaseModel):
+    min: float
+    max: float
+
+
+class MenuContentResponse(BaseModel):
+    description: str
+    dietary_tags: str
+    suggested_category: SuggestedCategory
+    price_band: PriceBand
+    prep_time_minutes: Optional[int] = None
+    agent: str
 
 
 class CategoryCreate(BaseModel):
@@ -150,6 +176,28 @@ async def create_menu_item(
         prep_time_minutes=db_item.prep_time_minutes,
         dietary_tags=db_item.dietary_tags,
     )
+
+
+@menu_router.post("/ai-generate", response_model=MenuContentResponse)
+async def ai_generate_menu_content(
+    request: MenuContentRequest,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Manager"]))
+):
+    """
+    Generează conținut AI pentru un produs nou (descriere, etichete, categorie, preț).
+    Non-destructiv: doar returnează o sugestie — managerul confirmă și salvează separat.
+    """
+    existing_categories = [c.name for c in session.exec(select(Category)).all()]
+
+    suggestion = await run_menu_content_agent(
+        name=request.name,
+        ingredients=request.ingredients or "",
+        existing_categories=existing_categories,
+        price_hint=request.price_hint,
+    )
+
+    return MenuContentResponse(**suggestion)
 
 
 @menu_router.post("/upload-image")

--- a/backend/api/reports.py
+++ b/backend/api/reports.py
@@ -43,25 +43,21 @@ def _parse_date(d: Optional[str]) -> date:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Format dată invalid: {d}. Folosește YYYY-MM-DD.")
 
 
-@router.get("/range", response_model=RangeReportRead)
-async def get_range_report(
-    start_date: Optional[str] = Query(default=None),
-    end_date: Optional[str] = Query(default=None),
-    session: Session = Depends(get_session),
-    current_user: User = Depends(require_role(["Manager"]))
-):
-    """Raport pe o perioadă — doar Manager."""
+def build_range_report(
+    session: Session,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> RangeReportRead:
+    """
+    Calculează raportul de vânzări pe o perioadă (revenue, comenzi, top items, revenue/zi).
+
+    Sursă unică de adevăr pentru raport — folosită atât de endpoint-ul /reports/range,
+    cât și de agentul AI de insights (api/insights.py). Datele lipsă (None) cad pe ziua curentă.
+    """
     today = datetime.now(timezone.utc).date()
 
-    if start_date:
-        start = _parse_date(start_date)
-    else:
-        start = today
-
-    if end_date:
-        end = _parse_date(end_date)
-    else:
-        end = today
+    start = _parse_date(start_date) if start_date else today
+    end = _parse_date(end_date) if end_date else today
 
     if start > end:
         start, end = end, start
@@ -116,3 +112,14 @@ async def get_range_report(
         top_items=top_items,
         revenue_by_day=revenue_by_day,
     )
+
+
+@router.get("/range", response_model=RangeReportRead)
+async def get_range_report(
+    start_date: Optional[str] = Query(default=None),
+    end_date: Optional[str] = Query(default=None),
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Manager"]))
+):
+    """Raport pe o perioadă — doar Manager."""
+    return build_range_report(session, start_date, end_date)

--- a/backend/core/ai.py
+++ b/backend/core/ai.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Any
 import json
+import re
 from openai import AsyncOpenAI
 from core.config import settings
 
@@ -104,6 +105,8 @@ CONVERSATION STYLE:
 - When recommending, suggest 2-3 specific dishes with clear reasoning
 - Include dish prices and brief descriptions
 - Guide customers toward placing an order
+- Keep response_text concise (max ~4 sentences) and include AT MOST 3 dishes in suggested_dishes
+- Reply in the same language the customer used
 
 Respond in this JSON format:
 {{"response_text": "Your conversational reply", "suggested_dishes": [{{"item_id": 1, "name": "Dish Name", "reasoning": "Why this matches", "price": 15.99}}], "follow_up_question": "Ask something to continue the conversation or null"}}"""
@@ -132,23 +135,21 @@ Respond in this JSON format:
             model=settings.DEEPSEEK_MODEL,
             messages=messages,
             temperature=0.4,
-            max_tokens=800
+            # 800 era prea puțin: la cereri în română cu mai multe feluri, JSON-ul
+            # se tăia la mijloc și parsarea pica → fallback. 1500 lasă spațiu să se
+            # închidă obiectul (output-ul e oricum plafonat la 3 feluri prin prompt).
+            max_tokens=1500,
+            # JSON mode: pe conversațiile multi-tur modelul „aluneca" în proză liberă
+            # (răspunsul pe turul 2+ nu mai conținea JSON → parse fail → fallback).
+            # Forțează emiterea unui obiect JSON valid. Promptul conține deja "JSON".
+            response_format={"type": "json_object"},
         )
 
-        # Try to parse JSON response, fallback to safe message if invalid
-        try:
-            response_text = response.choices[0].message.content.strip()
-            # Remove markdown code blocks if present
-            if response_text.startswith("```json"):
-                response_text = response_text[7:]
-            if response_text.startswith("```"):
-                response_text = response_text[3:]
-            if response_text.endswith("```"):
-                response_text = response_text[:-3]
-            response_text = response_text.strip()
-
-            result = json.loads(response_text)
-        except json.JSONDecodeError:
+        # Parse JSON robustly (modelul adaugă des proză în jurul JSON-ului, mai ales
+        # la cereri complexe). _extract_json izolează obiectul {...} din răspuns.
+        raw_content = response.choices[0].message.content or ""
+        result = _extract_json(raw_content)
+        if not result or not isinstance(result, dict):
             # SAFETY: Return safe fallback instead of arbitrary model output
             # This prevents off-topic/unsafe content from leaking through
             result = {
@@ -275,3 +276,345 @@ def clear_chat_session(session_id: str):
     """Clear chat history for a session"""
     if session_id in _chat_sessions:
         del _chat_sessions[session_id]
+
+
+def _extract_json(raw: str):
+    """
+    Extrage primul obiect JSON dintr-un răspuns al modelului. Întoarce dict sau
+    None dacă nu se poate parsa (apelantul decide ce fallback folosește).
+
+    Strategie: parse direct → strip code-fence ```json ... ``` → scanare cu
+    echilibrare de acolade pentru a izola exact blocul {...} din proză.
+    """
+    if not raw:
+        return None
+    text = raw.strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    fence = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", text, re.IGNORECASE)
+    if fence:
+        try:
+            return json.loads(fence.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    start = text.find("{")
+    if start != -1:
+        depth = 0
+        in_string = False
+        escape_next = False
+        for i, ch in enumerate(text[start:], start=start):
+            if escape_next:
+                escape_next = False
+                continue
+            if ch == "\\" and in_string:
+                escape_next = True
+                continue
+            if ch == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        return json.loads(text[start:i + 1])
+                    except json.JSONDecodeError:
+                        return None
+    return None
+
+
+# ============================================================================
+# AGENT AI 3: MANAGER ANALYTICS AGENT (conversational, session-based)
+# ============================================================================
+# Răspunde managerului la întrebări în limbaj natural despre datele de vânzări
+# (revenue, comenzi, top produse). Folosește același client DeepSeek + _extract_json.
+
+# Istoric separat de cel al clienților (_chat_sessions) ca să nu se amestece sesiunile.
+_insights_sessions: Dict[str, List[Dict]] = {}
+
+
+def _format_report_for_prompt(report: Dict[str, Any]) -> str:
+    """Compactează raportul într-un text lizibil pentru promptul modelului."""
+    top = ", ".join(
+        f"{t.get('name')} ({t.get('quantity_sold')} buc)"
+        for t in report.get("top_items", [])
+    ) or "fără date"
+    by_day = ", ".join(
+        f"{d.get('date')}: {d.get('revenue')} RON"
+        for d in report.get("revenue_by_day", [])
+    ) or "fără date"
+    return (
+        f"Perioadă: {report.get('start_date')} → {report.get('end_date')}\n"
+        f"Venit total: {report.get('total_revenue')} RON\n"
+        f"Număr comenzi: {report.get('total_orders')}\n"
+        f"Valoare medie comandă: {report.get('average_order_value')} RON\n"
+        f"Top produse: {top}\n"
+        f"Venit pe zile: {by_day}"
+    )
+
+
+def _format_menu_for_prompt(menu_items: List[Dict[str, Any]]) -> str:
+    """
+    Listă compactă cu prețul curent al fiecărui produs, pentru ca agentul să poată
+    sugera prețuri concrete (ex: happy hour) fără să inventeze valoarea de bază.
+    """
+    if not menu_items:
+        return ""
+    lines = []
+    for it in menu_items:
+        cat = it.get("category")
+        cat_txt = f" [{cat}]" if cat else ""
+        avail = "" if it.get("is_available", True) else " (indisponibil)"
+        lines.append(f"- {it.get('name')}{cat_txt}: {it.get('price')} RON{avail}")
+    return "PREȚURI MENIU (preț curent per produs):\n" + "\n".join(lines)
+
+
+def _insights_fallback(report: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    """Rezumat determinist al cifrelor când AI-ul nu e disponibil (fără API key)."""
+    insights = [
+        f"Venit total {report.get('total_revenue')} RON din {report.get('total_orders')} comenzi.",
+        f"Valoare medie pe comandă: {report.get('average_order_value')} RON.",
+    ]
+    top_items = report.get("top_items", [])
+    if top_items:
+        insights.append(f"Cel mai vândut produs: {top_items[0].get('name')}.")
+    return {
+        "response_text": (
+            "Asistentul AI nu este configurat momentan. Iată un rezumat al perioadei:\n"
+            + "\n".join(f"• {i}" for i in insights)
+        ),
+        "insights": insights,
+        "follow_up_question": None,
+        "session_id": session_id,
+        "agent": "fallback",
+    }
+
+
+async def run_manager_insights_agent(
+    message: str,
+    session_id: str,
+    report_data: Dict[str, Any],
+    menu_items: List[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Agent conversațional care analizează raportul de vânzări pentru manager.
+
+    SAFETY: răspunde DOAR despre datele/operațiunile acestui restaurant.
+    Păstrează istoricul conversației per session_id (ultimele 10 mesaje).
+
+    `menu_items` (opțional): listă cu prețul curent al produselor, ca agentul să
+    poată sugera prețuri concrete (ex: happy hour) fără să inventeze valoarea de bază.
+    """
+    if not settings.USE_AI_RECOMMENDATIONS or not settings.DEEPSEEK_API_KEY:
+        return _insights_fallback(report_data, session_id)
+
+    client = get_deepseek_client()
+    if not client:
+        return _insights_fallback(report_data, session_id)
+
+    menu_section = _format_menu_for_prompt(menu_items)
+    menu_block = f"\n\n{menu_section}" if menu_section else ""
+
+    system_prompt = f"""Ești un analist de business pentru un restaurant. Ajuți managerul să înțeleagă datele de vânzări.
+
+DATELE DE VÂNZĂRI PENTRU PERIOADA SELECTATĂ:
+{_format_report_for_prompt(report_data)}{menu_block}
+
+================================================================================
+REGULI STRICTE:
+================================================================================
+1. Răspunde DOAR despre aceste date de vânzări și despre operațiunile restaurantului
+   (venituri, comenzi, produse populare, tendințe, sugestii de promovare/meniu).
+2. Nu inventa cifre — folosește doar datele de mai sus. Dacă o cifră lipsește, spune asta.
+   Pentru sugestii de preț (ex: happy hour, reduceri) pornește de la prețul curent din
+   lista de prețuri a meniului și aplică reducerea, indicând atât prețul nou cât și procentul.
+3. Fii concis și concret. Oferă observații acționabile.
+
+Răspunde în acest format JSON:
+{{"response_text": "Răspunsul tău conversațional", "insights": ["observație 1", "observație 2"], "follow_up_question": "O întrebare de continuare sau null"}}"""
+
+    try:
+        history = _insights_sessions.get(session_id, [])
+        messages = [{"role": "system", "content": system_prompt}]
+        for msg in history:
+            if msg["role"] in ["user", "assistant"]:
+                messages.append({"role": msg["role"], "content": msg["content"]})
+        messages.append({"role": "user", "content": message})
+
+        response = await client.chat.completions.create(
+            model=settings.DEEPSEEK_MODEL,
+            messages=messages,
+            temperature=0.3,
+            max_tokens=1200,
+            # Același motiv ca la agentul de client: pe conversații multi-tur modelul
+            # poate aluneca în proză fără JSON. Forțăm un obiect JSON valid.
+            response_format={"type": "json_object"},
+        )
+        raw_content = response.choices[0].message.content or ""
+        result = _extract_json(raw_content)
+
+        # Parse eșuat sau răspuns gol → rezumat determinist.
+        if not result or not result.get("response_text"):
+            return _insights_fallback(report_data, session_id)
+        response_text = result["response_text"]
+
+        insights = result.get("insights", [])
+        if not isinstance(insights, list):
+            insights = []
+
+        history.append({"role": "user", "content": message})
+        history.append({"role": "assistant", "content": response_text})
+        _insights_sessions[session_id] = history[-10:]
+
+        return {
+            "response_text": response_text,
+            "insights": [str(i) for i in insights],
+            "follow_up_question": result.get("follow_up_question"),
+            "session_id": session_id,
+            "agent": settings.DEEPSEEK_MODEL,
+        }
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).warning("Manager insights agent error: %s", e)
+        return _insights_fallback(report_data, session_id)
+
+
+def clear_insights_session(session_id: str):
+    """Șterge istoricul conversației de insights pentru o sesiune."""
+    if session_id in _insights_sessions:
+        del _insights_sessions[session_id]
+
+
+# ============================================================================
+# AGENT AI 4: MENU CONTENT GENERATOR (single-shot, non-destructiv)
+# ============================================================================
+# Pentru manager: generează descriere, etichete dietetice, categorie sugerată și
+# interval de preț pentru un produs nou, pornind de la nume + ingrediente.
+
+def _menu_content_fallback(
+    name: str,
+    ingredients: str,
+    existing_categories: List[str],
+) -> Dict[str, Any]:
+    """Sugestie template când AI-ul nu e disponibil."""
+    desc = f"{name} preparat cu {ingredients}." if ingredients else f"{name} — preparatul casei."
+    return {
+        "description": desc[:500],
+        "dietary_tags": "",
+        "suggested_category": {
+            "name": existing_categories[0] if existing_categories else "General",
+            "is_new": not bool(existing_categories),
+        },
+        "price_band": {"min": 0.0, "max": 0.0},
+        "prep_time_minutes": None,
+        "agent": "fallback",
+    }
+
+
+async def run_menu_content_agent(
+    name: str,
+    ingredients: str = "",
+    existing_categories: List[str] = None,
+    price_hint: float = None,
+) -> Dict[str, Any]:
+    """
+    Generează conținut pentru un produs de meniu (single-shot).
+
+    Returnează descriere, etichete dietetice, categorie sugerată (cu flag is_new
+    recalculat pe server) și interval de preț. NU scrie nimic în baza de date.
+    """
+    existing_categories = existing_categories or []
+
+    def _finalize(result: Dict[str, Any], agent: str) -> Dict[str, Any]:
+        """Validează output-ul: recalculează is_new față de categoriile reale."""
+        # Modelul poate întoarce câmpuri cu tipuri neașteptate (string în loc de
+        # obiect) — tolerăm asta ca să nu pierdem o descriere altfel bună.
+        cat = result.get("suggested_category")
+        if isinstance(cat, dict):
+            cat_name = (cat.get("name") or "").strip()
+        elif isinstance(cat, str):
+            cat_name = cat.strip()
+        else:
+            cat_name = ""
+        cat_name = cat_name or (existing_categories[0] if existing_categories else "General")
+        # Sursa de adevăr pentru is_new e lista reală, nu ce zice modelul.
+        lookup = {c.lower(): c for c in existing_categories}
+        if cat_name.lower() in lookup:
+            cat_name = lookup[cat_name.lower()]
+            is_new = False
+        else:
+            is_new = True
+        band = result.get("price_band")
+        if not isinstance(band, dict):
+            band = {}
+        try:
+            band_min = round(float(band.get("min", 0.0)), 2)
+            band_max = round(float(band.get("max", 0.0)), 2)
+        except (TypeError, ValueError):
+            band_min = band_max = 0.0
+        prep = result.get("prep_time_minutes")
+        try:
+            prep = int(prep) if prep is not None else None
+        except (TypeError, ValueError):
+            prep = None
+        return {
+            "description": str(result.get("description", ""))[:500],
+            "dietary_tags": str(result.get("dietary_tags", ""))[:255],
+            "suggested_category": {"name": cat_name, "is_new": is_new},
+            "price_band": {"min": band_min, "max": band_max},
+            "prep_time_minutes": prep,
+            "agent": agent,
+        }
+
+    if not settings.USE_AI_RECOMMENDATIONS or not settings.DEEPSEEK_API_KEY:
+        return _menu_content_fallback(name, ingredients, existing_categories)
+
+    client = get_deepseek_client()
+    if not client:
+        return _menu_content_fallback(name, ingredients, existing_categories)
+
+    categories_text = ", ".join(existing_categories) if existing_categories else "(niciuna încă)"
+    price_text = f"\nPreț orientativ sugerat de manager: {price_hint} RON" if price_hint else ""
+    system_prompt = f"""Ești un copywriter culinar care creează conținut pentru meniul unui restaurant.
+
+CATEGORII EXISTENTE: {categories_text}
+
+Pentru produsul dat (nume + ingrediente), generează:
+- O descriere atrăgătoare pentru clienți (max 400 caractere).
+- Etichete dietetice/alergeni relevante, separate prin virgulă (ex: "vegetarian, fără gluten, conține nuci"). Lasă "" dacă nu e cazul.
+- Categoria potrivită: alege din categoriile existente dacă se potrivește una, altfel propune un nume nou.
+- Un interval de preț estimat în RON (min/max).
+- Timp de preparare estimat în minute (sau null).
+
+Răspunde DOAR cu JSON în acest format:
+{{"description": "...", "dietary_tags": "...", "suggested_category": {{"name": "...", "is_new": true}}, "price_band": {{"min": 0.0, "max": 0.0}}, "prep_time_minutes": 15}}"""
+
+    user_prompt = f"Nume produs: {name}\nIngrediente: {ingredients or 'nespecificate'}{price_text}"
+
+    try:
+        response = await client.chat.completions.create(
+            model=settings.DEEPSEEK_MODEL,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0.5,
+            max_tokens=800,
+        )
+        raw_content = response.choices[0].message.content or ""
+        result = _extract_json(raw_content)
+        if not result or not result.get("description"):
+            return _menu_content_fallback(name, ingredients, existing_categories)
+        return _finalize(result, settings.DEEPSEEK_MODEL)
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).warning("Menu content agent error: %s", e)
+        return _menu_content_fallback(name, ingredients, existing_categories)

--- a/backend/tests/unit/api/test_insights.py
+++ b/backend/tests/unit/api/test_insights.py
@@ -1,0 +1,84 @@
+"""
+Tests for the Manager Analytics (insights) AI agent endpoints.
+Covers: Manager-only access, rejection of other roles / no token,
+fallback response shape (no AI configured), and the clear endpoint.
+"""
+
+import pytest
+from unittest.mock import patch
+from main import app
+from models.user import User, UserRole
+from core.security import get_current_user
+
+
+@pytest.fixture
+def manager_client(client):
+    """client (real SQLite session) + authenticated Manager."""
+    def override_get_current_user():
+        return User(id=1, email="manager@test.com", name="Mgr", role=UserRole.manager,
+                    hashed_password="pw", phone="22233344")
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    yield client
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+def waiter_client(client):
+    def override_get_current_user():
+        return User(id=2, email="waiter@test.com", name="Wtr", role=UserRole.waiter,
+                    hashed_password="pw", phone="33344455")
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    yield client
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+class TestInsightsAuth:
+    def test_chat_requires_token(self, client):
+        resp = client.post("/api/insights/chat", json={"message": "Cum merg vânzările?"})
+        assert resp.status_code == 401
+
+    def test_chat_rejects_non_manager(self, waiter_client):
+        resp = waiter_client.post("/api/insights/chat", json={"message": "Raport?"})
+        assert resp.status_code == 403
+
+    def test_clear_rejects_non_manager(self, waiter_client):
+        resp = waiter_client.post("/api/insights/chat/clear", json={"session_id": "x"})
+        assert resp.status_code == 403
+
+
+class TestInsightsFallback:
+    def test_chat_fallback_shape(self, manager_client):
+        """Empty DB + no AI key → deterministic fallback over zeroed report."""
+        with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+            resp = manager_client.post(
+                "/api/insights/chat",
+                json={"message": "Rezumă perioada", "start_date": "2026-05-01", "end_date": "2026-05-07"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["agent"] == "fallback"
+        assert "response_text" in data
+        assert isinstance(data["insights"], list)
+        assert data["session_id"]  # auto-generated when absent
+
+    def test_chat_preserves_session_id(self, manager_client):
+        with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+            resp = manager_client.post(
+                "/api/insights/chat",
+                json={"message": "Salut", "session_id": "fixed-session"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["session_id"] == "fixed-session"
+
+    def test_clear_session(self, manager_client):
+        resp = manager_client.post("/api/insights/chat/clear", json={"session_id": "abc"})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "cleared"
+
+    def test_chat_invalid_date_422(self, manager_client):
+        with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+            resp = manager_client.post(
+                "/api/insights/chat",
+                json={"message": "x", "start_date": "not-a-date"},
+            )
+        assert resp.status_code == 422

--- a/backend/tests/unit/api/test_menu.py
+++ b/backend/tests/unit/api/test_menu.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from models.user import User, UserRole
 from models.category import Category
 from models.menu_item import MenuItem
@@ -80,3 +80,31 @@ def test_delete_category_with_items(auth_client, mock_db_session):
     response = auth_client.delete("/api/categories/1")
     assert response.status_code == 400
     assert "Nu se poate șterge categoria" in response.json()["detail"]
+
+
+# --- AI Menu Content Generator (/menu/ai-generate) ---
+
+def test_ai_generate_requires_manager(client):
+    """No auth → 401 (Manager-only endpoint)."""
+    response = client.post("/api/menu/ai-generate", json={"name": "Pizza"})
+    assert response.status_code == 401
+
+def test_ai_generate_fallback_shape(auth_client, mock_db_session):
+    """No AI key → deterministic fallback suggestion, no DB writes."""
+    mock_db_session.exec.return_value.all.return_value = [
+        Category(id=1, name="Pizza"), Category(id=2, name="Băuturi")
+    ]
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+        response = auth_client.post(
+            "/api/menu/ai-generate",
+            json={"name": "Pizza Margherita", "ingredients": "rosii, mozzarella"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["agent"] == "fallback"
+    assert "Pizza Margherita" in data["description"]
+    assert "suggested_category" in data and "is_new" in data["suggested_category"]
+    assert "price_band" in data
+    # Non-destructiv: nu se scrie nimic în DB
+    mock_db_session.add.assert_not_called()
+    mock_db_session.commit.assert_not_called()

--- a/backend/tests/unit/api/test_recommendations.py
+++ b/backend/tests/unit/api/test_recommendations.py
@@ -44,13 +44,16 @@ class TestRecommendationsAuth:
     def test_chat_valid_guest_token(self, client_with_db):
         """Valid guest token should access recommendations with fallback (no AI configured)."""
         token = create_guest_token(table_id=1)
-        
-        response = client_with_db.post(
-            "/api/recommendations/chat",
-            json={"message": "I want something spicy"},
-            headers={"Authorization": f"Bearer {token}"}
-        )
-        
+
+        # Forțăm fallback-ul explicit ca testul să fie determinist indiferent dacă
+        # mediul local are DEEPSEEK_API_KEY setat în .env.
+        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
+            response = client_with_db.post(
+                "/api/recommendations/chat",
+                json={"message": "I want something spicy"},
+                headers={"Authorization": f"Bearer {token}"}
+            )
+
         assert response.status_code == 200
         data = response.json()
         assert "response_text" in data

--- a/backend/tests/unit/core/test_ai.py
+++ b/backend/tests/unit/core/test_ai.py
@@ -1,5 +1,13 @@
+import json
 import pytest
-from core.ai import run_ai_kds_optimizer, run_ai_safety_agent
+from unittest.mock import AsyncMock, MagicMock, patch
+from core.ai import (
+    run_ai_kds_optimizer,
+    run_ai_safety_agent,
+    run_manager_insights_agent,
+    run_menu_content_agent,
+    clear_insights_session,
+)
 
 def test_run_ai_kds_optimizer_high_complexity():
     items = [{"prep_time": 15}, {"prep_time": 15}]
@@ -20,3 +28,168 @@ def test_run_ai_safety_agent_normal():
     notes = "Vreau mai mult sos"
     result = run_ai_safety_agent(notes)
     assert result == "NORMAL"
+
+
+# ============================================================================
+# AGENT AI 3: Manager Analytics Agent
+# ============================================================================
+
+SAMPLE_REPORT = {
+    "start_date": "2026-05-01",
+    "end_date": "2026-05-07",
+    "total_revenue": 1250.5,
+    "total_orders": 40,
+    "average_order_value": 31.26,
+    "top_items": [{"name": "Burger", "quantity_sold": 25}],
+    "revenue_by_day": [{"date": "2026-05-01", "revenue": 200.0}],
+}
+
+
+def _mock_client_returning(content: str):
+    """Build an AsyncOpenAI-like mock whose completion returns `content`."""
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "stop"
+    completion = MagicMock()
+    completion.choices = [choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=completion)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_insights_fallback_when_no_api_key():
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+        result = await run_manager_insights_agent("Cum au fost vânzările?", "s1", SAMPLE_REPORT)
+    assert result["agent"] == "fallback"
+    assert result["session_id"] == "s1"
+    assert isinstance(result["insights"], list) and result["insights"]
+    # Rezumatul determinist trebuie să conțină cifra reală
+    assert "1250.5" in result["response_text"]
+
+
+@pytest.mark.asyncio
+async def test_insights_agent_parses_model_json():
+    payload = json.dumps({
+        "response_text": "Vânzările au crescut.",
+        "insights": ["Burger e cel mai vândut", "Venit 1250.5 RON"],
+        "follow_up_question": "Vrei detalii pe zile?",
+    })
+    mock_client = _mock_client_returning(payload)
+    clear_insights_session("s-json")
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_manager_insights_agent("De ce a crescut?", "s-json", SAMPLE_REPORT)
+    assert result["agent"] != "fallback"
+    assert result["response_text"] == "Vânzările au crescut."
+    assert result["insights"] == ["Burger e cel mai vândut", "Venit 1250.5 RON"]
+    assert result["follow_up_question"] == "Vrei detalii pe zile?"
+
+
+@pytest.mark.asyncio
+async def test_insights_agent_session_history_accumulates():
+    mock_client = _mock_client_returning(json.dumps({"response_text": "ok", "insights": []}))
+    clear_insights_session("s-hist")
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        await run_manager_insights_agent("Q1", "s-hist", SAMPLE_REPORT)
+        await run_manager_insights_agent("Q2", "s-hist", SAMPLE_REPORT)
+    from core.ai import _insights_sessions
+    # 2 mesaje user + 2 assistant
+    assert len(_insights_sessions["s-hist"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_insights_agent_falls_back_on_unparseable_response():
+    mock_client = _mock_client_returning("not json at all, just prose")
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_manager_insights_agent("Q", "s-bad", SAMPLE_REPORT)
+    # _extract_json cade pe textul de recomandare meniu → tratat ca eșec → fallback insights
+    assert result["agent"] == "fallback"
+
+
+# ============================================================================
+# AGENT AI 4: Menu Content Generator
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_menu_content_fallback_when_no_api_key():
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+        result = await run_menu_content_agent("Pizza Margherita", "rosii, mozzarella", ["Pizza"])
+    assert result["agent"] == "fallback"
+    assert "Pizza Margherita" in result["description"]
+    # categoria sugerată e una existentă → nu e nouă
+    assert result["suggested_category"]["is_new"] is False
+
+
+@pytest.mark.asyncio
+async def test_menu_content_recomputes_is_new_for_existing_category():
+    # Modelul pretinde is_new=True pentru o categorie care de fapt EXISTĂ.
+    payload = json.dumps({
+        "description": "Pizza clasică italiană.",
+        "dietary_tags": "vegetarian",
+        "suggested_category": {"name": "pizza", "is_new": True},
+        "price_band": {"min": 25, "max": 40},
+        "prep_time_minutes": 15,
+    })
+    mock_client = _mock_client_returning(payload)
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_menu_content_agent("Pizza Margherita", "rosii", ["Pizza", "Băuturi"])
+    # Server recalculează: "pizza" se potrivește cu "Pizza" existentă → is_new False, nume normalizat
+    assert result["suggested_category"]["is_new"] is False
+    assert result["suggested_category"]["name"] == "Pizza"
+    assert result["dietary_tags"] == "vegetarian"
+    assert result["price_band"] == {"min": 25.0, "max": 40.0}
+    assert result["prep_time_minutes"] == 15
+
+
+@pytest.mark.asyncio
+async def test_menu_content_tolerates_malformed_field_types():
+    # Modelul întoarce suggested_category ca string și price_band ca listă —
+    # tipuri greșite. Agentul nu trebuie să arunce descrierea bună la gunoi.
+    payload = json.dumps({
+        "description": "Salată proaspătă.",
+        "dietary_tags": "vegan",
+        "suggested_category": "Salate",   # string în loc de obiect
+        "price_band": [10, 20],            # listă în loc de obiect
+        "prep_time_minutes": "abc",        # ne-numeric
+    })
+    mock_client = _mock_client_returning(payload)
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_menu_content_agent("Salată Caesar", "salată", ["Pizza"])
+    # Păstrează descrierea (nu cade pe fallback), normalizează tipurile greșite.
+    assert result["agent"] != "fallback"
+    assert result["description"] == "Salată proaspătă."
+    assert result["dietary_tags"] == "vegan"
+    assert result["suggested_category"] == {"name": "Salate", "is_new": True}
+    assert result["price_band"] == {"min": 0.0, "max": 0.0}
+    assert result["prep_time_minutes"] is None
+
+
+@pytest.mark.asyncio
+async def test_menu_content_flags_genuinely_new_category():
+    payload = json.dumps({
+        "description": "Desert cremos.",
+        "dietary_tags": "",
+        "suggested_category": {"name": "Deserturi", "is_new": False},
+        "price_band": {"min": 10, "max": 20},
+        "prep_time_minutes": None,
+    })
+    mock_client = _mock_client_returning(payload)
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_menu_content_agent("Tiramisu", "mascarpone", ["Pizza"])
+    # "Deserturi" nu există în listă → is_new True, indiferent ce a zis modelul
+    assert result["suggested_category"]["is_new"] is True
+    assert result["suggested_category"]["name"] == "Deserturi"

--- a/frontend/__tests__/app/manager/ClientPage.test.tsx
+++ b/frontend/__tests__/app/manager/ClientPage.test.tsx
@@ -93,6 +93,48 @@ describe('Manager Dashboard', () => {
     expect(screen.getByRole('button', { name: 'Adaugă Produs' })).toBeInTheDocument()
   })
 
+  it('fills the product form from the AI content generator', async () => {
+    const ok = (data: unknown) =>
+      ({ ok: true, json: () => Promise.resolve(data) }) as unknown as Response
+    vi.mocked(api.apiRequest).mockImplementation((url: string) => {
+      if (url === '/menu') {
+        return Promise.resolve(ok([{ id: 1, name: 'Burger', price: 20, category: 'Food', is_available: true }]))
+      }
+      if (url === '/categories') {
+        return Promise.resolve(ok([{ id: 1, name: 'Food' }]))
+      }
+      if (url === '/manager/stats') {
+        return Promise.resolve(ok({ total_revenue: 0, total_orders: 0, menu_items_count: 1 }))
+      }
+      if (url === '/menu/ai-generate') {
+        return Promise.resolve(ok({
+          description: 'Un burger suculent cu vită Wagyu.',
+          dietary_tags: 'conține gluten',
+          suggested_category: { name: 'Food', is_new: false },
+          price_band: { min: 30, max: 45 },
+          prep_time_minutes: 12,
+          agent: 'deepseek-v4-flash',
+        }))
+      }
+      return Promise.resolve(ok({}))
+    })
+
+    render(<ManagerPage />)
+    await waitFor(() => expect(screen.getByText('Burger')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('+ Adaugă Produs Nou'))
+    // Numele e necesar pentru a activa butonul AI.
+    fireEvent.change(screen.getByPlaceholderText('Ex: Burger Wagyu'), { target: { value: 'Burger Wagyu' } })
+    fireEvent.click(screen.getByRole('button', { name: /Generează cu AI/i }))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Un burger suculent cu vită Wagyu.')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('conține gluten')).toBeInTheDocument()
+    })
+    // Intervalul de preț sugerat e afișat ca hint.
+    expect(screen.getByText(/Interval de preț sugerat/i)).toBeInTheDocument()
+  })
+
   it('can switch tabs', async () => {
     render(<ManagerPage />)
     

--- a/frontend/__tests__/components/AIChatWidget.test.tsx
+++ b/frontend/__tests__/components/AIChatWidget.test.tsx
@@ -1,14 +1,15 @@
-"""
-Tests for AIChatWidget component.
-Covers: messages render, loading state, add-to-cart callback, and API mocking.
-"""
+/**
+ * Tests for AIChatWidget component.
+ * Covers: messages render, loading state, add-to-cart callback, and API mocking.
+ */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { AIChatWidget } from "@/components/AIChatWidget";
 
-// Mock fetch globally
-global.fetch = vi.fn();
+// Mock fetch globally (typed reference avoids `as any` at each call site)
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
 
 describe("AIChatWidget", () => {
   const mockOnAddToCart = vi.fn();
@@ -18,7 +19,7 @@ describe("AIChatWidget", () => {
     Storage.prototype.getItem = vi.fn(() => "mock-token");
     
     // Mock successful API response
-    (fetch as any).mockResolvedValue({
+    mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
         response_text: "Here are some dishes you might like!",
@@ -67,7 +68,7 @@ describe("AIChatWidget", () => {
 
   it("shows loading state while waiting for API response", async () => {
     // Delay the fetch response
-    (fetch as any).mockImplementation(() => 
+    mockFetch.mockImplementation(() => 
       new Promise((resolve) => setTimeout(resolve, 100))
     );
     
@@ -188,7 +189,7 @@ describe("AIChatWidget", () => {
     
     // Wait for second API call with session_id
     await waitFor(() => {
-      const calls = (fetch as any).mock.calls;
+      const calls = mockFetch.mock.calls;
       const lastCall = calls[calls.length - 1];
       const body = JSON.parse(lastCall[1].body);
       
@@ -206,10 +207,9 @@ describe("AIChatWidget", () => {
       expect(screen.getByText("AI Food Assistant")).toBeInTheDocument();
     });
     
-    // Click X button
-    const closeButton = screen.getByRole("button", { name: "" }); // X icon button
-    fireEvent.click(closeButton);
-    
+    // Click X button (labeled for accessibility)
+    fireEvent.click(screen.getByRole("button", { name: /close chat/i }));
+
     // Should show launch button again
     await waitFor(() => {
       expect(screen.getByText("Let AI recommend me something")).toBeInTheDocument();
@@ -218,7 +218,7 @@ describe("AIChatWidget", () => {
 
   it("handles API error gracefully", async () => {
     // Mock failed API response
-    (fetch as any).mockRejectedValue(new Error("Network error"));
+    mockFetch.mockRejectedValue(new Error("Network error"));
     
     render(<AIChatWidget onAddToCart={mockOnAddToCart} />);
     
@@ -233,32 +233,32 @@ describe("AIChatWidget", () => {
 
   it("does not send message when input is empty", async () => {
     render(<AIChatWidget onAddToCart={mockOnAddToCart} />);
-    
-    // Open chat
+
+    // Open chat — this auto-sends a greeting, so wait for that round-trip first
     fireEvent.click(screen.getByText("Let AI recommend me something"));
-    
+
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/Tell me what you're craving/i)).toBeInTheDocument();
+      expect(screen.getByText("Here are some dishes you might like!")).toBeInTheDocument();
     });
-    
-    // Try to send empty message
+
+    // Reset the fetch counter, then press Enter on an empty input
+    mockFetch.mockClear();
     const input = screen.getByPlaceholderText(/Tell me what you're craving/i);
     fireEvent.keyDown(input, { key: "Enter" });
-    
-    // Should not call fetch
+
+    // Empty input must not trigger another request
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("does not open chat when no token is available", () => {
+  it("does not call the recommendation API when no token is available", () => {
     // Mock no token
     Storage.prototype.getItem = vi.fn(() => null);
-    
+
     render(<AIChatWidget onAddToCart={mockOnAddToCart} />);
-    
-    // Try to open chat
+
+    // Opening the chat is allowed, but without a token nothing is sent
     fireEvent.click(screen.getByText("Let AI recommend me something"));
-    
-    // Should not show chat content
-    expect(screen.queryByText("AI Food Assistant")).not.toBeInTheDocument();
+
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/__tests__/components/ManagerInsightsChat.test.tsx
+++ b/frontend/__tests__/components/ManagerInsightsChat.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ManagerInsightsChat } from '@/components/ManagerInsightsChat'
+import * as api from '@/lib/api'
+
+vi.mock('@/lib/api', () => ({ apiRequest: vi.fn() }))
+
+// Răspuns minimal compatibil cu Response, fără a folosi `any`.
+const okResponse = (data: unknown) =>
+  ({ ok: true, json: () => Promise.resolve(data) }) as unknown as Response
+
+describe('ManagerInsightsChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.apiRequest).mockResolvedValue(
+      okResponse({
+        response_text: 'Vânzările au fost bune.',
+        insights: ['Top produs: Burger'],
+        follow_up_question: null,
+        session_id: 'sess-1',
+        agent: 'fallback',
+      }),
+    )
+  })
+
+  it('shows the empty-state prompt and suggestion chips', () => {
+    render(<ManagerInsightsChat startDate="2026-05-01" endDate="2026-05-07" />)
+    expect(screen.getByText(/Întreabă-mă orice/i)).toBeInTheDocument()
+    expect(screen.getByText('Care e cel mai vândut produs?')).toBeInTheDocument()
+  })
+
+  it('sends a question and renders the AI response with insights', async () => {
+    render(<ManagerInsightsChat startDate="2026-05-01" endDate="2026-05-07" />)
+
+    const field = screen.getByPlaceholderText(/Scrie o întrebare/i)
+    fireEvent.change(field, { target: { value: 'Cum a fost luna?' } })
+    fireEvent.submit(field.closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vânzările au fost bune.')).toBeInTheDocument()
+      expect(screen.getByText('Top produs: Burger')).toBeInTheDocument()
+    })
+
+    // Trimite mesajul + perioada selectată către backend.
+    expect(api.apiRequest).toHaveBeenCalledWith(
+      '/insights/chat',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"start_date":"2026-05-01"'),
+      }),
+    )
+  })
+
+  it('sends a suggestion chip when clicked', async () => {
+    render(<ManagerInsightsChat startDate="2026-05-01" endDate="2026-05-07" />)
+    fireEvent.click(screen.getByText('Care e cel mai vândut produs?'))
+    await waitFor(() => {
+      expect(screen.getByText('Vânzările au fost bune.')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/app/manager/ClientPage.tsx
+++ b/frontend/app/manager/ClientPage.tsx
@@ -7,7 +7,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import UserProfileMenu from "@/components/ui/UserProfileMenu";
 import ClientRoleGuard from "@/components/ClientRoleGuard";
 import { apiRequest } from "@/lib/api";
-import { Pencil, Trash2 } from "lucide-react";
+import { ManagerInsightsChat } from "@/components/ManagerInsightsChat";
+import { Pencil, Trash2, Sparkles } from "lucide-react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
@@ -70,6 +71,11 @@ export default function ManagerPage() {
   const [formPrepTime, setFormPrepTime] = useState("");
   const [formDietary, setFormDietary] = useState("");
   const [isFormAvailable, setIsFormAvailable] = useState(true);
+
+  // AI menu content generator (non-destructiv: doar populează formularul)
+  const [aiGenerating, setAiGenerating] = useState(false);
+  const [aiNewCategory, setAiNewCategory] = useState<string | null>(null);
+  const [aiPriceBand, setAiPriceBand] = useState<{ min: number; max: number } | null>(null);
 
   const [previewImage, setPreviewImage] = useState<string | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
@@ -140,6 +146,8 @@ export default function ManagerPage() {
     setPreviewImage(null);
     setImageUrl(null);
     setCompressionStats(null);
+    setAiNewCategory(null);
+    setAiPriceBand(null);
   }
 
   function handleAddNew() {
@@ -161,7 +169,58 @@ export default function ManagerPage() {
     setIsFormAvailable(item.is_available);
     setPreviewImage(item.image_url);
     setImageUrl(item.image_url);
+    setAiNewCategory(null);
+    setAiPriceBand(null);
     setIsModalOpen(true);
+  }
+
+  async function handleAiGenerate() {
+    if (formName.trim().length < 2) {
+      showToast("Introdu un nume de produs (minim 2 caractere)", "error");
+      return;
+    }
+    setAiGenerating(true);
+    setAiNewCategory(null);
+    try {
+      // price_hint trebuie să fie > 0 (backend respinge 0); altfel îl omitem.
+      const priceHint = formPrice ? parseFloat(formPrice) : NaN;
+      const res = await apiRequest("/menu/ai-generate", {
+        method: "POST",
+        body: JSON.stringify({
+          name: formName.trim(),
+          ingredients: formIngredients.trim() || null,
+          price_hint: priceHint > 0 ? priceHint : null,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(typeof err.detail === "string" ? err.detail : "Generare eșuată");
+      }
+      const data = await res.json();
+      if (data.description) setFormDescription(data.description);
+      if (data.dietary_tags) setFormDietary(data.dietary_tags);
+      if (data.prep_time_minutes != null) setFormPrepTime(String(data.prep_time_minutes));
+      if (data.price_band) setAiPriceBand(data.price_band);
+      const cat = data.suggested_category;
+      if (cat) {
+        if (cat.is_new) {
+          // Categorie nouă: nu o creăm automat — îi spunem managerului s-o adauge.
+          setAiNewCategory(cat.name);
+        } else {
+          const match = categories.find((c) => c.name.toLowerCase() === cat.name.toLowerCase());
+          if (match) setFormCategoryId(match.id.toString());
+        }
+      }
+      showToast(
+        data.agent === "fallback"
+          ? "Sugestie generată (AI indisponibil — text de bază)"
+          : "Conținut generat cu AI"
+      );
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : "Eroare la generare", "error");
+    } finally {
+      setAiGenerating(false);
+    }
   }
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -462,12 +521,18 @@ export default function ManagerPage() {
           <DialogContent className="bg-slate-900 border-slate-700 text-white sm:max-w-[550px] max-h-[90vh] overflow-y-auto">
             <DialogHeader><DialogTitle className="text-2xl font-bold text-green-400">{editingItem ? "Editează Produs" : "Adaugă Produs Nou"}</DialogTitle></DialogHeader>
             <div className="grid gap-4 py-2">
+              <div className="flex items-center justify-between bg-slate-800/50 border border-slate-700 rounded-lg px-3 py-2">
+                <span className="text-xs text-slate-400">Completează automat descrierea, tag-urile și categoria cu AI</span>
+                <Button type="button" size="sm" onClick={handleAiGenerate} disabled={aiGenerating || formName.trim().length < 2} className="bg-purple-600 hover:bg-purple-500 font-semibold shrink-0"><Sparkles size={14} className="mr-1.5" />{aiGenerating ? "Se generează..." : "Generează cu AI"}</Button>
+              </div>
               <div><label className="text-sm text-slate-400 mb-1.5 block">Nume Produs *</label><input type="text" value={formName} onChange={(e) => setFormName(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-green-500 outline-none transition-colors" placeholder="Ex: Burger Wagyu" /></div>
               <div><label className="text-sm text-slate-400 mb-1.5 block">Descriere</label><textarea value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-green-500 outline-none transition-colors min-h-[80px] resize-y" placeholder="Descrierea produsului..." /></div>
               <div className="grid grid-cols-2 gap-4">
                 <div><label className="text-sm text-slate-400 mb-1.5 block">Preț (RON) *</label><input type="number" step="0.01" min="0.01" value={formPrice} onChange={(e) => setFormPrice(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-green-500 outline-none transition-colors" placeholder="0.00" /></div>
                 <div><label className="text-sm text-slate-400 mb-1.5 block">Categorie *</label><select value={formCategoryId} onChange={(e) => setFormCategoryId(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white focus:border-green-500 outline-none transition-colors"><option value="">Selectează...</option>{categories.map((cat) => (<option key={cat.id} value={cat.id}>{cat.name}</option>))}</select></div>
               </div>
+              {aiPriceBand && (aiPriceBand.min > 0 || aiPriceBand.max > 0) && <p className="text-xs text-purple-300">💡 Interval de preț sugerat de AI: {aiPriceBand.min}–{aiPriceBand.max} RON</p>}
+              {aiNewCategory && <p className="text-xs text-purple-300">💡 AI sugerează o categorie nouă: <b>{aiNewCategory}</b> — creează-o din tab-ul „Categorii”, apoi selecteaz-o aici.</p>}
               <div><label className="text-sm text-slate-400 mb-1.5 block">Imagine Produs</label><div className="flex gap-3 items-start"><div className="flex-1"><input type="file" ref={fileInputRef} accept="image/jpeg,image/png,image/webp,image/gif" onChange={handleFileChange} className="w-full text-sm text-slate-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-slate-800 file:text-green-400 file:font-medium hover:file:bg-slate-700 file:cursor-pointer file:transition-colors" />{uploadingImage && <p className="text-xs text-yellow-400 mt-1.5">Se încarcă și se optimizează imaginea...</p>}{compressionStats && <p className="text-xs text-green-400 mt-1.5">✓ Optimizat: {(compressionStats.original / 1024).toFixed(1)}KB → {(compressionStats.optimized / 1024).toFixed(1)}KB</p>}</div>{previewImage && <img src={previewImage} alt="Preview" className="w-16 h-16 rounded-lg object-cover border border-slate-700 shrink-0" />}</div></div>
               <div><label className="text-sm text-slate-400 mb-1.5 block">Ingrediente</label><input type="text" value={formIngredients} onChange={(e) => setFormIngredients(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-green-500 outline-none transition-colors" placeholder="Ex: carne vită, cheddar, ceapă" /></div>
               <div className="grid grid-cols-2 gap-4">
@@ -622,6 +687,7 @@ export default function ManagerPage() {
           )}
           </>
         )}
+        <ManagerInsightsChat key={`${reportStart}_${reportEnd}`} startDate={reportStart} endDate={reportEnd} />
         </>
         )}
 

--- a/frontend/components/AIChatWidget.tsx
+++ b/frontend/components/AIChatWidget.tsx
@@ -111,7 +111,7 @@ export function AIChatWidget({ onAddToCart }: AIChatWidgetProps) {
           <Sparkles className="mr-2 h-4 w-4 text-yellow-400" />
           AI Food Assistant
         </CardTitle>
-        <Button variant="ghost" size="sm" onClick={() => setIsOpen(false)} className="text-slate-400 hover:text-white hover:bg-slate-800">
+        <Button variant="ghost" size="sm" aria-label="Close chat" onClick={() => setIsOpen(false)} className="text-slate-400 hover:text-white hover:bg-slate-800">
           <X className="h-4 w-4" />
         </Button>
       </CardHeader>

--- a/frontend/components/ManagerInsightsChat.tsx
+++ b/frontend/components/ManagerInsightsChat.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Sparkles, Send } from "lucide-react";
+import { apiRequest } from "@/lib/api";
+
+interface InsightMessage {
+  role: "user" | "ai";
+  content: string;
+  insights?: string[];
+}
+
+interface ManagerInsightsChatProps {
+  startDate: string;
+  endDate: string;
+}
+
+const SUGGESTIONS = [
+  "Cum au fost vânzările în această perioadă?",
+  "Care e cel mai vândut produs?",
+  "Ce ar trebui să promovez?",
+];
+
+export function ManagerInsightsChat({ startDate, endDate }: ManagerInsightsChatProps) {
+  const [messages, setMessages] = useState<InsightMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Notă: când se schimbă perioada (startDate/endDate), părintele remontează
+  // componenta printr-un `key` nou, deci starea (sesiune + mesaje) se resetează
+  // singură — context curat de raport, fără efect care apelează setState.
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, isLoading]);
+
+  const sendMessage = async (msg: string) => {
+    if (!msg.trim() || isLoading) return;
+    setInput("");
+    setIsLoading(true);
+    setMessages((prev) => [...prev, { role: "user", content: msg }]);
+
+    try {
+      const res = await apiRequest("/insights/chat", {
+        method: "POST",
+        body: JSON.stringify({
+          message: msg,
+          session_id: sessionId,
+          start_date: startDate,
+          end_date: endDate,
+        }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setSessionId(data.session_id);
+      setMessages((prev) => [
+        ...prev,
+        { role: "ai", content: data.response_text, insights: data.insights },
+      ]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { role: "ai", content: "Nu am putut obține un răspuns. Încearcă din nou." },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card className="bg-slate-900 border-slate-800 mt-10">
+      <CardHeader>
+        <CardTitle className="text-slate-400 text-sm uppercase flex items-center gap-2">
+          <Sparkles size={16} className="text-green-400" /> Asistent AI Analiză
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div ref={scrollRef} className="max-h-80 overflow-y-auto space-y-3 mb-4">
+          {messages.length === 0 && (
+            <p className="text-slate-500 text-sm">
+              Întreabă-mă orice despre datele de vânzări din perioada selectată.
+            </p>
+          )}
+          {messages.map((m, i) => (
+            <div key={i} className={m.role === "user" ? "text-right" : "text-left"}>
+              <div
+                className={`inline-block px-3 py-2 rounded-lg text-sm max-w-[90%] ${
+                  m.role === "user" ? "bg-green-600 text-white" : "bg-slate-800 text-slate-100"
+                }`}
+              >
+                <p className="whitespace-pre-wrap">{m.content}</p>
+                {m.insights && m.insights.length > 0 && (
+                  <ul className="mt-2 list-disc list-inside text-slate-300 text-xs space-y-0.5">
+                    {m.insights.map((ins, j) => (
+                      <li key={j}>{ins}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          ))}
+          {isLoading && <p className="text-slate-500 text-sm">Se analizează...</p>}
+        </div>
+
+        {messages.length === 0 && (
+          <div className="flex flex-wrap gap-2 mb-3">
+            {SUGGESTIONS.map((s) => (
+              <button
+                key={s}
+                onClick={() => sendMessage(s)}
+                className="px-3 py-1 rounded-full text-xs bg-slate-800 text-slate-300 hover:bg-slate-700"
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            sendMessage(input);
+          }}
+          className="flex gap-2"
+        >
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Scrie o întrebare despre vânzări..."
+            className="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-white placeholder-slate-500 focus:border-green-500 outline-none text-sm"
+          />
+          <Button type="submit" disabled={isLoading} className="bg-green-600 hover:bg-green-500">
+            <Send size={16} />
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Manager-side AI:
- insights agent (api/insights.py): conversational sales-report analysis, now fed current menu prices so it can suggest concrete happy-hour/discount prices instead of generic percentages
- menu content generator + range-report price data (api/menu.py, api/reports.py)
- frontend ManagerInsightsChat + manager page wiring

Customer recommendation agent (core/ai.py) reliability fixes:
- replace naive json.loads with robust _extract_json parser
- raise max_tokens 800->1500 so long Romanian multi-dish replies aren't truncated mid-JSON
- enable JSON mode (response_format=json_object) to stop multi-turn prose-drift that broke parsing on 2nd+ turns
- prompt: keep replies concise, cap at 3 dishes, answer in user's language

Tests:
- make test_chat_valid_guest_token deterministic (force fallback regardless of local .env)
- add insights agent tests; update menu/ai unit tests