### PR TITLE
fix(evals): build mock DeepSeek JSON with json.dumps, not str().replace

### DIFF
--- a/backend/tests/evals/test_recommendation_quality.py
+++ b/backend/tests/evals/test_recommendation_quality.py
@@ -5,6 +5,7 @@ Evaluates if AI suggests relevant dishes for expressed preferences.
 Metrics: Precision@3, Recall@10, NDCG@3, Category Diversity
 """
 
+import json
 import pytest
 from typing import Dict, List, Any
 from unittest.mock import patch
@@ -41,7 +42,7 @@ class TestRecommendationRelevance:
             async def mock_create(*args, **kwargs):
                 class MockChoice:
                     class Message:
-                        content = str(mock_response).replace("'", '"')
+                        content = json.dumps(mock_response)
                     message = Message()
                 class MockResp:
                     choices = [MockChoice()]
@@ -77,7 +78,7 @@ class TestRecommendationRelevance:
             async def mock_create(*args, **kwargs):
                 class MockChoice:
                     class Message:
-                        content = str(mock_response).replace("'", '"')
+                        content = json.dumps(mock_response)
                     message = Message()
                 class MockResp:
                     choices = [MockChoice()]


### PR DESCRIPTION
test_vegan_relevance / test_spicy_relevance built the mocked model response via str(dict).replace("'", '"'). That corrupts as soon as a value contains an apostrophe — "Spicy lovers, you're in for a treat!" became invalid JSON, so the parser failed, the agent fell back, and Precision@3 collapsed to 0 (flaky/false failure). It also mis-renders None/True/False.

Use json.dumps(mock_response) so the mock is always valid JSON. test_spicy_relevance now passes deterministically.