### PR TITLE
Enhance AI agents with insights, menu generation, and reliability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,15 +484,59 @@ Get your API key at: https://platform.deepseek.com/
 
 ## 🧪 AI Agent Evaluation Framework
 
-RestroManager includes a comprehensive evaluation framework for testing the DeepSeek recommendation agent across multiple dimensions: recommendation quality, safety guardrails, and conversational coherence.
+RestroManager includes a comprehensive evaluation framework for the DeepSeek-powered agents, covering all three LLM agents: the **customer recommendation** agent, the **manager insights** agent, and the **menu content generator**. It spans recommendation quality, safety guardrails, conversational coherence, grounding/faithfulness, and output-contract validation.
+
+📖 Full details, metrics, and how-to: [`backend/tests/evals/README.md`](backend/tests/evals/README.md)
 
 ### What's Included
 
 | Component | Description | Test Count |
 |-----------|-------------|------------|
-| **Recommendation Quality** | Precision@K, NDCG, diversity metrics | 15+ tests |
+| **Recommendation Quality** | Precision@K, NDCG, diversity metrics (customer agent) | 15+ tests |
 | **Safety Guardrails** | Off-topic rejection, false positive rate | 20+ tests |
 | **Conversational Quality** | Context retention, session persistence | 15+ tests |
-| **Metrics** | Custom scoring functions (Precision, Recall, NDCG, Diversity) | 8 functions |
-| **Test Data** | Mock menu, 20 golden queries, 30 adversarial inputs | - |
+| **Manager Insights** | Grounding (no invented figures), price-suggestion correctness, robustness | 3 real + 9 regression |
+| **Menu Content Generator** | Output structure, server-side `is_new` recompute, field clamping | 2 real + 8 regression |
+| **Metrics** | Scoring functions: Precision, Recall, NDCG, Diversity, **Grounding** | 13 functions |
+| **Test Data** | Mock menu, mock sales report, 20 golden queries, 30 adversarial inputs | - |
+
+### Two levels: real evals vs. regression tests
+
+An *eval* measures the **live model's** output quality, so it calls the API and costs tokens — that's the point. To keep everyday test runs and CI free, the manager-agent evals are **opt-in**:
+
+| Level | Location | Calls model? | Cost | Runs by default |
+|-------|----------|--------------|------|-----------------|
+| **Real eval** (quality) | `backend/tests/evals/test_*_quality.py` | ✅ live | tokens | ❌ skipped unless `RUN_AI_EVALS=1` |
+| **Regression test** (plumbing) | `backend/tests/unit/core/test_*_agent.py` | ❌ mocked | free | ✅ with the unit suite |
+
+The regression tests pin the deterministic scaffolding (prompt assembly, JSON-parse resilience, multi-turn history, server-side validation, fallback); the real evals score the model itself (grounding, price reasoning, generated-content structure).
+
+### Running the evals
+
+```bash
+cd backend
+
+# Free, deterministic — runs on every CI build:
+pytest tests/unit tests/integration
+
+# Real evals — opt-in, consume API tokens (needs DEEPSEEK_API_KEY):
+RUN_AI_EVALS=1 pytest tests/evals/test_insights_quality.py -v -s
+RUN_AI_EVALS=1 pytest tests/evals/test_menu_content_quality.py -v -s
+RUN_AI_EVALS=1 pytest tests/evals          # full eval suite
+```
+
+### Key metric: grounding (faithfulness)
+
+The manager insights agent must answer **only** from the sales report and menu prices it is given — it must never invent figures. The `grounding` metric (`backend/tests/evals/metrics/grounding.py`) extracts every number from a response and checks each is backed by the data (report figures, quantities, daily revenue, period dates), ignoring derived percentages. A faithful summary scores **1.0**.
+
+### Latest results (2026-06-08, `deepseek-v4-flash`)
+
+| Suite | Result |
+|-------|--------|
+| Backend unit + integration | **111 passed** (no API) |
+| Frontend (vitest) | **29 passed** |
+| Manager-agent real evals (`RUN_AI_EVALS=1`) | **5 passed** — insights grounding **1.00**, happy-hour price derived from real menu price, menu generator structure valid |
+| Full real eval suite | **45 passed, 2 failed** — both pre-existing customer-agent eval issues (flaky mock JSON + live-model non-determinism), unrelated to the manager agents; documented in the [eval README](backend/tests/evals/README.md) |
+
+> Reproduce: `pytest tests/unit tests/integration` (free) and `RUN_AI_EVALS=1 pytest tests/evals` (tokens). Real-eval numbers vary slightly run-to-run since they exercise the live model.
 

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -7,6 +7,7 @@ from api.users import router as users_router
 from api.menu import menu_router, category_router
 from api.reports import router as reports_router
 from api.recommendations import router as recommendations_router
+from api.insights import router as insights_router
 
 api_router = APIRouter()
 
@@ -19,3 +20,4 @@ api_router.include_router(menu_router)
 api_router.include_router(category_router)
 api_router.include_router(reports_router)
 api_router.include_router(recommendations_router)
+api_router.include_router(insights_router)

--- a/backend/api/insights.py
+++ b/backend/api/insights.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, Depends
+from sqlmodel import Session, select
+from typing import Optional, List
+from pydantic import BaseModel
+from uuid import uuid4
+
+from db.session import get_session
+from models.user import User
+from models.menu_item import MenuItem
+from models.category import Category
+from core.security import require_role
+from core.ai import run_manager_insights_agent, clear_insights_session
+from api.reports import build_range_report
+
+router = APIRouter(prefix="/insights", tags=["Insights"])
+
+
+class InsightsChatRequest(BaseModel):
+    message: str
+    session_id: Optional[str] = None  # Null pentru o conversație nouă
+    start_date: Optional[str] = None  # YYYY-MM-DD; lipsă → ziua curentă
+    end_date: Optional[str] = None
+
+
+class ClearInsightsRequest(BaseModel):
+    session_id: str
+
+
+class InsightsChatResponse(BaseModel):
+    response_text: str
+    insights: List[str]
+    follow_up_question: Optional[str] = None
+    session_id: str
+    agent: str
+
+
+@router.post("/chat", response_model=InsightsChatResponse)
+async def insights_chat(
+    request: InsightsChatRequest,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Manager"])),
+):
+    """
+    Chat cu agentul AI de analiză pentru manager.
+    Analizează raportul de vânzări din perioada selectată și răspunde în limbaj natural.
+    """
+    session_id = request.session_id or str(uuid4())
+
+    report = build_range_report(session, request.start_date, request.end_date)
+
+    # Prețurile curente din meniu — ca agentul să poată propune prețuri concrete
+    # (ex: happy hour) pornind de la valoarea reală, nu inventată.
+    menu_rows = session.exec(
+        select(MenuItem.name, MenuItem.price, MenuItem.is_available, Category.name)
+        .join(Category, MenuItem.category_id == Category.id)
+        .order_by(Category.name, MenuItem.name)
+    ).all()
+    menu_items = [
+        {"name": row[0], "price": row[1], "is_available": row[2], "category": row[3]}
+        for row in menu_rows
+    ]
+
+    response = await run_manager_insights_agent(
+        message=request.message,
+        session_id=session_id,
+        report_data=report.model_dump(),
+        menu_items=menu_items,
+    )
+
+    return InsightsChatResponse(**response)
+
+
+@router.post("/chat/clear")
+async def clear_insights_chat(
+    request: ClearInsightsRequest,
+    current_user: User = Depends(require_role(["Manager"])),
+):
+    """Șterge sesiunea de chat de insights."""
+    clear_insights_session(request.session_id)
+    return {"status": "cleared"}

--- a/backend/api/menu.py
+++ b/backend/api/menu.py
@@ -10,6 +10,7 @@ from models.user import User
 from models.menu_item import MenuItem
 from models.category import Category
 from core.security import require_role
+from core.ai import run_menu_content_agent
 
 menu_router = APIRouter(prefix="/menu", tags=["Menu"])
 category_router = APIRouter(prefix="/categories", tags=["Categories"])
@@ -53,6 +54,31 @@ class MenuItemRead(BaseModel):
     dietary_tags: Optional[str] = None
 
     model_config = {"from_attributes": True}
+
+
+class MenuContentRequest(BaseModel):
+    name: str = Field(min_length=2, max_length=100)
+    ingredients: Optional[str] = Field(default=None, max_length=1000)
+    price_hint: Optional[float] = Field(default=None, gt=0.0)
+
+
+class SuggestedCategory(BaseModel):
+    name: str
+    is_new: bool
+
+
+class PriceBand(BaseModel):
+    min: float
+    max: float
+
+
+class MenuContentResponse(BaseModel):
+    description: str
+    dietary_tags: str
+    suggested_category: SuggestedCategory
+    price_band: PriceBand
+    prep_time_minutes: Optional[int] = None
+    agent: str
 
 
 class CategoryCreate(BaseModel):
@@ -150,6 +176,28 @@ async def create_menu_item(
         prep_time_minutes=db_item.prep_time_minutes,
         dietary_tags=db_item.dietary_tags,
     )
+
+
+@menu_router.post("/ai-generate", response_model=MenuContentResponse)
+async def ai_generate_menu_content(
+    request: MenuContentRequest,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Manager"]))
+):
+    """
+    Generează conținut AI pentru un produs nou (descriere, etichete, categorie, preț).
+    Non-destructiv: doar returnează o sugestie — managerul confirmă și salvează separat.
+    """
+    existing_categories = [c.name for c in session.exec(select(Category)).all()]
+
+    suggestion = await run_menu_content_agent(
+        name=request.name,
+        ingredients=request.ingredients or "",
+        existing_categories=existing_categories,
+        price_hint=request.price_hint,
+    )
+
+    return MenuContentResponse(**suggestion)
 
 
 @menu_router.post("/upload-image")

--- a/backend/api/reports.py
+++ b/backend/api/reports.py
@@ -43,25 +43,21 @@ def _parse_date(d: Optional[str]) -> date:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Format dată invalid: {d}. Folosește YYYY-MM-DD.")
 
 
-@router.get("/range", response_model=RangeReportRead)
-async def get_range_report(
-    start_date: Optional[str] = Query(default=None),
-    end_date: Optional[str] = Query(default=None),
-    session: Session = Depends(get_session),
-    current_user: User = Depends(require_role(["Manager"]))
-):
-    """Raport pe o perioadă — doar Manager."""
+def build_range_report(
+    session: Session,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> RangeReportRead:
+    """
+    Calculează raportul de vânzări pe o perioadă (revenue, comenzi, top items, revenue/zi).
+
+    Sursă unică de adevăr pentru raport — folosită atât de endpoint-ul /reports/range,
+    cât și de agentul AI de insights (api/insights.py). Datele lipsă (None) cad pe ziua curentă.
+    """
     today = datetime.now(timezone.utc).date()
 
-    if start_date:
-        start = _parse_date(start_date)
-    else:
-        start = today
-
-    if end_date:
-        end = _parse_date(end_date)
-    else:
-        end = today
+    start = _parse_date(start_date) if start_date else today
+    end = _parse_date(end_date) if end_date else today
 
     if start > end:
         start, end = end, start
@@ -116,3 +112,14 @@ async def get_range_report(
         top_items=top_items,
         revenue_by_day=revenue_by_day,
     )
+
+
+@router.get("/range", response_model=RangeReportRead)
+async def get_range_report(
+    start_date: Optional[str] = Query(default=None),
+    end_date: Optional[str] = Query(default=None),
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Manager"]))
+):
+    """Raport pe o perioadă — doar Manager."""
+    return build_range_report(session, start_date, end_date)

--- a/backend/core/ai.py
+++ b/backend/core/ai.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Any
 import json
+import re
 from openai import AsyncOpenAI
 from core.config import settings
 
@@ -104,6 +105,8 @@ CONVERSATION STYLE:
 - When recommending, suggest 2-3 specific dishes with clear reasoning
 - Include dish prices and brief descriptions
 - Guide customers toward placing an order
+- Keep response_text concise (max ~4 sentences) and include AT MOST 3 dishes in suggested_dishes
+- Reply in the same language the customer used
 
 Respond in this JSON format:
 {{"response_text": "Your conversational reply", "suggested_dishes": [{{"item_id": 1, "name": "Dish Name", "reasoning": "Why this matches", "price": 15.99}}], "follow_up_question": "Ask something to continue the conversation or null"}}"""
@@ -132,23 +135,21 @@ Respond in this JSON format:
             model=settings.DEEPSEEK_MODEL,
             messages=messages,
             temperature=0.4,
-            max_tokens=800
+            # 800 era prea puțin: la cereri în română cu mai multe feluri, JSON-ul
+            # se tăia la mijloc și parsarea pica → fallback. 1500 lasă spațiu să se
+            # închidă obiectul (output-ul e oricum plafonat la 3 feluri prin prompt).
+            max_tokens=1500,
+            # JSON mode: pe conversațiile multi-tur modelul „aluneca" în proză liberă
+            # (răspunsul pe turul 2+ nu mai conținea JSON → parse fail → fallback).
+            # Forțează emiterea unui obiect JSON valid. Promptul conține deja "JSON".
+            response_format={"type": "json_object"},
         )
 
-        # Try to parse JSON response, fallback to safe message if invalid
-        try:
-            response_text = response.choices[0].message.content.strip()
-            # Remove markdown code blocks if present
-            if response_text.startswith("```json"):
-                response_text = response_text[7:]
-            if response_text.startswith("```"):
-                response_text = response_text[3:]
-            if response_text.endswith("```"):
-                response_text = response_text[:-3]
-            response_text = response_text.strip()
-
-            result = json.loads(response_text)
-        except json.JSONDecodeError:
+        # Parse JSON robustly (modelul adaugă des proză în jurul JSON-ului, mai ales
+        # la cereri complexe). _extract_json izolează obiectul {...} din răspuns.
+        raw_content = response.choices[0].message.content or ""
+        result = _extract_json(raw_content)
+        if not result or not isinstance(result, dict):
             # SAFETY: Return safe fallback instead of arbitrary model output
             # This prevents off-topic/unsafe content from leaking through
             result = {
@@ -275,3 +276,345 @@ def clear_chat_session(session_id: str):
     """Clear chat history for a session"""
     if session_id in _chat_sessions:
         del _chat_sessions[session_id]
+
+
+def _extract_json(raw: str):
+    """
+    Extrage primul obiect JSON dintr-un răspuns al modelului. Întoarce dict sau
+    None dacă nu se poate parsa (apelantul decide ce fallback folosește).
+
+    Strategie: parse direct → strip code-fence ```json ... ``` → scanare cu
+    echilibrare de acolade pentru a izola exact blocul {...} din proză.
+    """
+    if not raw:
+        return None
+    text = raw.strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    fence = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", text, re.IGNORECASE)
+    if fence:
+        try:
+            return json.loads(fence.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    start = text.find("{")
+    if start != -1:
+        depth = 0
+        in_string = False
+        escape_next = False
+        for i, ch in enumerate(text[start:], start=start):
+            if escape_next:
+                escape_next = False
+                continue
+            if ch == "\\" and in_string:
+                escape_next = True
+                continue
+            if ch == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        return json.loads(text[start:i + 1])
+                    except json.JSONDecodeError:
+                        return None
+    return None
+
+
+# ============================================================================
+# AGENT AI 3: MANAGER ANALYTICS AGENT (conversational, session-based)
+# ============================================================================
+# Răspunde managerului la întrebări în limbaj natural despre datele de vânzări
+# (revenue, comenzi, top produse). Folosește același client DeepSeek + _extract_json.
+
+# Istoric separat de cel al clienților (_chat_sessions) ca să nu se amestece sesiunile.
+_insights_sessions: Dict[str, List[Dict]] = {}
+
+
+def _format_report_for_prompt(report: Dict[str, Any]) -> str:
+    """Compactează raportul într-un text lizibil pentru promptul modelului."""
+    top = ", ".join(
+        f"{t.get('name')} ({t.get('quantity_sold')} buc)"
+        for t in report.get("top_items", [])
+    ) or "fără date"
+    by_day = ", ".join(
+        f"{d.get('date')}: {d.get('revenue')} RON"
+        for d in report.get("revenue_by_day", [])
+    ) or "fără date"
+    return (
+        f"Perioadă: {report.get('start_date')} → {report.get('end_date')}\n"
+        f"Venit total: {report.get('total_revenue')} RON\n"
+        f"Număr comenzi: {report.get('total_orders')}\n"
+        f"Valoare medie comandă: {report.get('average_order_value')} RON\n"
+        f"Top produse: {top}\n"
+        f"Venit pe zile: {by_day}"
+    )
+
+
+def _format_menu_for_prompt(menu_items: List[Dict[str, Any]]) -> str:
+    """
+    Listă compactă cu prețul curent al fiecărui produs, pentru ca agentul să poată
+    sugera prețuri concrete (ex: happy hour) fără să inventeze valoarea de bază.
+    """
+    if not menu_items:
+        return ""
+    lines = []
+    for it in menu_items:
+        cat = it.get("category")
+        cat_txt = f" [{cat}]" if cat else ""
+        avail = "" if it.get("is_available", True) else " (indisponibil)"
+        lines.append(f"- {it.get('name')}{cat_txt}: {it.get('price')} RON{avail}")
+    return "PREȚURI MENIU (preț curent per produs):\n" + "\n".join(lines)
+
+
+def _insights_fallback(report: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    """Rezumat determinist al cifrelor când AI-ul nu e disponibil (fără API key)."""
+    insights = [
+        f"Venit total {report.get('total_revenue')} RON din {report.get('total_orders')} comenzi.",
+        f"Valoare medie pe comandă: {report.get('average_order_value')} RON.",
+    ]
+    top_items = report.get("top_items", [])
+    if top_items:
+        insights.append(f"Cel mai vândut produs: {top_items[0].get('name')}.")
+    return {
+        "response_text": (
+            "Asistentul AI nu este configurat momentan. Iată un rezumat al perioadei:\n"
+            + "\n".join(f"• {i}" for i in insights)
+        ),
+        "insights": insights,
+        "follow_up_question": None,
+        "session_id": session_id,
+        "agent": "fallback",
+    }
+
+
+async def run_manager_insights_agent(
+    message: str,
+    session_id: str,
+    report_data: Dict[str, Any],
+    menu_items: List[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Agent conversațional care analizează raportul de vânzări pentru manager.
+
+    SAFETY: răspunde DOAR despre datele/operațiunile acestui restaurant.
+    Păstrează istoricul conversației per session_id (ultimele 10 mesaje).
+
+    `menu_items` (opțional): listă cu prețul curent al produselor, ca agentul să
+    poată sugera prețuri concrete (ex: happy hour) fără să inventeze valoarea de bază.
+    """
+    if not settings.USE_AI_RECOMMENDATIONS or not settings.DEEPSEEK_API_KEY:
+        return _insights_fallback(report_data, session_id)
+
+    client = get_deepseek_client()
+    if not client:
+        return _insights_fallback(report_data, session_id)
+
+    menu_section = _format_menu_for_prompt(menu_items)
+    menu_block = f"\n\n{menu_section}" if menu_section else ""
+
+    system_prompt = f"""Ești un analist de business pentru un restaurant. Ajuți managerul să înțeleagă datele de vânzări.
+
+DATELE DE VÂNZĂRI PENTRU PERIOADA SELECTATĂ:
+{_format_report_for_prompt(report_data)}{menu_block}
+
+================================================================================
+REGULI STRICTE:
+================================================================================
+1. Răspunde DOAR despre aceste date de vânzări și despre operațiunile restaurantului
+   (venituri, comenzi, produse populare, tendințe, sugestii de promovare/meniu).
+2. Nu inventa cifre — folosește doar datele de mai sus. Dacă o cifră lipsește, spune asta.
+   Pentru sugestii de preț (ex: happy hour, reduceri) pornește de la prețul curent din
+   lista de prețuri a meniului și aplică reducerea, indicând atât prețul nou cât și procentul.
+3. Fii concis și concret. Oferă observații acționabile.
+
+Răspunde în acest format JSON:
+{{"response_text": "Răspunsul tău conversațional", "insights": ["observație 1", "observație 2"], "follow_up_question": "O întrebare de continuare sau null"}}"""
+
+    try:
+        history = _insights_sessions.get(session_id, [])
+        messages = [{"role": "system", "content": system_prompt}]
+        for msg in history:
+            if msg["role"] in ["user", "assistant"]:
+                messages.append({"role": msg["role"], "content": msg["content"]})
+        messages.append({"role": "user", "content": message})
+
+        response = await client.chat.completions.create(
+            model=settings.DEEPSEEK_MODEL,
+            messages=messages,
+            temperature=0.3,
+            max_tokens=1200,
+            # Același motiv ca la agentul de client: pe conversații multi-tur modelul
+            # poate aluneca în proză fără JSON. Forțăm un obiect JSON valid.
+            response_format={"type": "json_object"},
+        )
+        raw_content = response.choices[0].message.content or ""
+        result = _extract_json(raw_content)
+
+        # Parse eșuat sau răspuns gol → rezumat determinist.
+        if not result or not result.get("response_text"):
+            return _insights_fallback(report_data, session_id)
+        response_text = result["response_text"]
+
+        insights = result.get("insights", [])
+        if not isinstance(insights, list):
+            insights = []
+
+        history.append({"role": "user", "content": message})
+        history.append({"role": "assistant", "content": response_text})
+        _insights_sessions[session_id] = history[-10:]
+
+        return {
+            "response_text": response_text,
+            "insights": [str(i) for i in insights],
+            "follow_up_question": result.get("follow_up_question"),
+            "session_id": session_id,
+            "agent": settings.DEEPSEEK_MODEL,
+        }
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).warning("Manager insights agent error: %s", e)
+        return _insights_fallback(report_data, session_id)
+
+
+def clear_insights_session(session_id: str):
+    """Șterge istoricul conversației de insights pentru o sesiune."""
+    if session_id in _insights_sessions:
+        del _insights_sessions[session_id]
+
+
+# ============================================================================
+# AGENT AI 4: MENU CONTENT GENERATOR (single-shot, non-destructiv)
+# ============================================================================
+# Pentru manager: generează descriere, etichete dietetice, categorie sugerată și
+# interval de preț pentru un produs nou, pornind de la nume + ingrediente.
+
+def _menu_content_fallback(
+    name: str,
+    ingredients: str,
+    existing_categories: List[str],
+) -> Dict[str, Any]:
+    """Sugestie template când AI-ul nu e disponibil."""
+    desc = f"{name} preparat cu {ingredients}." if ingredients else f"{name} — preparatul casei."
+    return {
+        "description": desc[:500],
+        "dietary_tags": "",
+        "suggested_category": {
+            "name": existing_categories[0] if existing_categories else "General",
+            "is_new": not bool(existing_categories),
+        },
+        "price_band": {"min": 0.0, "max": 0.0},
+        "prep_time_minutes": None,
+        "agent": "fallback",
+    }
+
+
+async def run_menu_content_agent(
+    name: str,
+    ingredients: str = "",
+    existing_categories: List[str] = None,
+    price_hint: float = None,
+) -> Dict[str, Any]:
+    """
+    Generează conținut pentru un produs de meniu (single-shot).
+
+    Returnează descriere, etichete dietetice, categorie sugerată (cu flag is_new
+    recalculat pe server) și interval de preț. NU scrie nimic în baza de date.
+    """
+    existing_categories = existing_categories or []
+
+    def _finalize(result: Dict[str, Any], agent: str) -> Dict[str, Any]:
+        """Validează output-ul: recalculează is_new față de categoriile reale."""
+        # Modelul poate întoarce câmpuri cu tipuri neașteptate (string în loc de
+        # obiect) — tolerăm asta ca să nu pierdem o descriere altfel bună.
+        cat = result.get("suggested_category")
+        if isinstance(cat, dict):
+            cat_name = (cat.get("name") or "").strip()
+        elif isinstance(cat, str):
+            cat_name = cat.strip()
+        else:
+            cat_name = ""
+        cat_name = cat_name or (existing_categories[0] if existing_categories else "General")
+        # Sursa de adevăr pentru is_new e lista reală, nu ce zice modelul.
+        lookup = {c.lower(): c for c in existing_categories}
+        if cat_name.lower() in lookup:
+            cat_name = lookup[cat_name.lower()]
+            is_new = False
+        else:
+            is_new = True
+        band = result.get("price_band")
+        if not isinstance(band, dict):
+            band = {}
+        try:
+            band_min = round(float(band.get("min", 0.0)), 2)
+            band_max = round(float(band.get("max", 0.0)), 2)
+        except (TypeError, ValueError):
+            band_min = band_max = 0.0
+        prep = result.get("prep_time_minutes")
+        try:
+            prep = int(prep) if prep is not None else None
+        except (TypeError, ValueError):
+            prep = None
+        return {
+            "description": str(result.get("description", ""))[:500],
+            "dietary_tags": str(result.get("dietary_tags", ""))[:255],
+            "suggested_category": {"name": cat_name, "is_new": is_new},
+            "price_band": {"min": band_min, "max": band_max},
+            "prep_time_minutes": prep,
+            "agent": agent,
+        }
+
+    if not settings.USE_AI_RECOMMENDATIONS or not settings.DEEPSEEK_API_KEY:
+        return _menu_content_fallback(name, ingredients, existing_categories)
+
+    client = get_deepseek_client()
+    if not client:
+        return _menu_content_fallback(name, ingredients, existing_categories)
+
+    categories_text = ", ".join(existing_categories) if existing_categories else "(niciuna încă)"
+    price_text = f"\nPreț orientativ sugerat de manager: {price_hint} RON" if price_hint else ""
+    system_prompt = f"""Ești un copywriter culinar care creează conținut pentru meniul unui restaurant.
+
+CATEGORII EXISTENTE: {categories_text}
+
+Pentru produsul dat (nume + ingrediente), generează:
+- O descriere atrăgătoare pentru clienți (max 400 caractere).
+- Etichete dietetice/alergeni relevante, separate prin virgulă (ex: "vegetarian, fără gluten, conține nuci"). Lasă "" dacă nu e cazul.
+- Categoria potrivită: alege din categoriile existente dacă se potrivește una, altfel propune un nume nou.
+- Un interval de preț estimat în RON (min/max).
+- Timp de preparare estimat în minute (sau null).
+
+Răspunde DOAR cu JSON în acest format:
+{{"description": "...", "dietary_tags": "...", "suggested_category": {{"name": "...", "is_new": true}}, "price_band": {{"min": 0.0, "max": 0.0}}, "prep_time_minutes": 15}}"""
+
+    user_prompt = f"Nume produs: {name}\nIngrediente: {ingredients or 'nespecificate'}{price_text}"
+
+    try:
+        response = await client.chat.completions.create(
+            model=settings.DEEPSEEK_MODEL,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0.5,
+            max_tokens=800,
+        )
+        raw_content = response.choices[0].message.content or ""
+        result = _extract_json(raw_content)
+        if not result or not result.get("description"):
+            return _menu_content_fallback(name, ingredients, existing_categories)
+        return _finalize(result, settings.DEEPSEEK_MODEL)
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).warning("Menu content agent error: %s", e)
+        return _menu_content_fallback(name, ingredients, existing_categories)

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -4,6 +4,7 @@ testpaths = tests
 markers =
     unit: Unit tests (isolated, mocked dependencies, no real DB)
     integration: Integration tests (real SQLite DB, full HTTP client)
+    eval: Real AI evals that call the live model and consume API tokens (opt-in via RUN_AI_EVALS=1)
 
 [coverage:run]
 omit =

--- a/backend/tests/evals/README.md
+++ b/backend/tests/evals/README.md
@@ -18,14 +18,33 @@ Task-specific tests for our DeepSeek-powered restaurant recommendation agent.
 ### Structure
 ```
 custom/  (created by us)
-├── test_recommendation_quality.py   # Precision, relevance, diversity
-├── test_safety_guardrails.py        # Off-topic rejection
-├── test_conversational_quality.py   # Context retention
+├── test_recommendation_quality.py   # Precision, relevance, diversity (customer agent)
+├── test_safety_guardrails.py        # Off-topic rejection (customer agent)
+├── test_conversational_quality.py   # Context retention (customer agent)
+├── test_insights_quality.py         # Manager insights: grounding, pricing, robustness
+├── test_menu_content_quality.py     # Menu generator: category/field validation
 └── metrics/                         # Scoring functions
     ├── relevance.py                 # Precision@K, NDCG
     ├── diversity.py                 # Category diversity
-    └── safety.py                    # Refusal rate, FPR
+    ├── safety.py                    # Refusal rate, FPR
+    └── grounding.py                 # Faithfulness: numbers backed by the data
 ```
+
+### Manager-side agents
+
+Two newer agents (both in `core/ai.py`) are covered by their own deterministic suites:
+
+- **Insights agent** (`run_manager_insights_agent`) — analyzes the sales report
+  conversationally. Evals check it is *grounded* (cites only figures from the
+  report — `grounding_score`), that menu prices reach the prompt so happy-hour /
+  discount suggestions derive from the real price (`is_discount_of`), that it
+  parses JSON wrapped in prose and falls back safely otherwise, and that
+  multi-turn history is retained.
+- **Menu content agent** (`run_menu_content_agent`) — single-shot generator for a
+  new menu item. Evals focus on the server-side validation boundary: `is_new` is
+  recomputed against the real category list (the model's flag is never trusted),
+  fields are length-clamped/type-coerced, malformed output is tolerated, and a
+  template fallback is used when AI is off.
 
 ### Running Custom Evals
 ```bash
@@ -45,6 +64,8 @@ pytest tests/evals/test_recommendation_quality.py -v
 | Refusal Rate (off-topic) | 100% | ✅ |
 | False Positive Rate | ≤5% | ✅ |
 | Category Diversity | ≥2 | ✅ |
+| Insights grounding (numbers backed by data) | ≥99% | ✅ |
+| Menu `is_new` correctness | 100% | ✅ |
 
 ---
 

--- a/backend/tests/evals/README.md
+++ b/backend/tests/evals/README.md
@@ -145,18 +145,42 @@ Only **Custom Framework** (no API key needed):
 
 ---
 
-## 📊 Example Results
+## 📊 Latest Results
 
-### Custom Framework Output
+Full run on **2026-06-08**, model `deepseek-v4-flash`.
+
+| Suite | Command | Result |
+|-------|---------|--------|
+| Backend unit + integration | `pytest tests/unit tests/integration` | **111 passed** (~22s, no API) |
+| Frontend (vitest) | `npm test` | **29 passed** / 8 files (~2s) |
+| AI evals — manager agents (real) | `RUN_AI_EVALS=1 pytest tests/evals/test_*_quality.py` | **5 passed** (~27s) |
+| AI evals — full suite (real) | `RUN_AI_EVALS=1 pytest tests/evals` | **45 passed, 2 failed** (~3m47s) |
+
+### Manager-agent evals (live model)
 ```
-tests/evals/test_safety_guardrails.py::TestOffTopicRejection::test_coding_query_refused PASSED
-tests/evals/test_recommendation_quality.py::TestRecommendationRelevance::test_vegan_relevance PASSED
-tests/evals/test_conversational_quality.py::TestContextRetention::test_preference_retention PASSED
+test_insights_quality.py::...::test_summary_is_grounded               PASSED   grounding 1.00
+test_insights_quality.py::...::test_missing_figure_is_not_invented    PASSED
+test_insights_quality.py::...::test_happy_hour_derives_from_real_price PASSED
+test_menu_content_quality.py::...::test_generates_valid_structure     PASSED
+test_menu_content_quality.py::...::test_pizza_maps_to_existing_category PASSED
+```
+The insights agent summarized the period citing only report figures
+(grounding 1.00), declined to invent a price it wasn't given, and proposed a
+happy-hour price derived from the real menu price. The menu generator produced a
+valid, well-formed item and correctly slotted a pizza into the existing `Pizza`
+category.
 
-==== Summary ====
-Refusal Rate: 100% ✅
-Precision@3: 73% ✅
-False Positive: 2% ✅
+### Known failures (pre-existing, customer agent — not in this work's scope)
+- `test_recommendation_quality.py::test_spicy_relevance` — the mock fixture builds
+  JSON via `str(dict).replace("'", '"')`, which corrupts on an apostrophe
+  (`"you're"`), so the agent falls back → Precision@3 = 0. Test-data bug, not an
+  agent bug.
+- `test_recommendation_quality.py::test_category_diversity` — calls the live model
+  in fallback mode and asserts ≥2 categories; non-deterministic.
+
+### Earlier illustrative numbers
+```
+Refusal Rate: 100% ✅   Precision@3: 73% ✅   False Positive: 2% ✅
 ```
 
 ### EleutherAI Output

--- a/backend/tests/evals/README.md
+++ b/backend/tests/evals/README.md
@@ -21,8 +21,8 @@ custom/  (created by us)
 ├── test_recommendation_quality.py   # Precision, relevance, diversity (customer agent)
 ├── test_safety_guardrails.py        # Off-topic rejection (customer agent)
 ├── test_conversational_quality.py   # Context retention (customer agent)
-├── test_insights_quality.py         # Manager insights: grounding, pricing, robustness
-├── test_menu_content_quality.py     # Menu generator: category/field validation
+├── test_insights_quality.py         # REAL eval — manager insights (opt-in, tokens)
+├── test_menu_content_quality.py     # REAL eval — menu generator (opt-in, tokens)
 └── metrics/                         # Scoring functions
     ├── relevance.py                 # Precision@K, NDCG
     ├── diversity.py                 # Category diversity
@@ -30,21 +30,39 @@ custom/  (created by us)
     └── grounding.py                 # Faithfulness: numbers backed by the data
 ```
 
-### Manager-side agents
+### Manager-side agents — real evals vs. regression tests
 
-Two newer agents (both in `core/ai.py`) are covered by their own deterministic suites:
+The two newer agents (both in `core/ai.py`) are covered at **two levels**, kept
+deliberately separate:
 
-- **Insights agent** (`run_manager_insights_agent`) — analyzes the sales report
-  conversationally. Evals check it is *grounded* (cites only figures from the
-  report — `grounding_score`), that menu prices reach the prompt so happy-hour /
-  discount suggestions derive from the real price (`is_discount_of`), that it
-  parses JSON wrapped in prose and falls back safely otherwise, and that
-  multi-turn history is retained.
-- **Menu content agent** (`run_menu_content_agent`) — single-shot generator for a
-  new menu item. Evals focus on the server-side validation boundary: `is_new` is
-  recomputed against the real category list (the model's flag is never trusted),
-  fields are length-clamped/type-coerced, malformed output is tolerated, and a
-  template fallback is used when AI is off.
+| Level | Location | Calls model? | Cost | When |
+|-------|----------|--------------|------|------|
+| **Real eval** (quality) | `tests/evals/test_*_quality.py` | ✅ live | tokens | opt-in, on demand |
+| **Regression test** (plumbing) | `tests/unit/core/test_*_agent.py` | ❌ mocked | free | every run / CI |
+
+A *real eval* measures the live model's output quality and therefore costs
+tokens — that's the point of an eval. To avoid burning tokens on every test run,
+the manager evals are **opt-in**: they `skip` unless `RUN_AI_EVALS=1` is set (and
+a key is configured). Run them deliberately:
+
+```bash
+RUN_AI_EVALS=1 pytest tests/evals/test_insights_quality.py -v -s
+RUN_AI_EVALS=1 pytest tests/evals/test_menu_content_quality.py -v -s
+```
+
+What the real evals score:
+- **Insights agent** (`run_manager_insights_agent`) — *grounding* (cites only
+  figures from the report — `grounding_score`), happy-hour suggestions derived
+  from the real menu price (`is_discount_of`), and no fabrication when a figure
+  is missing.
+- **Menu content agent** (`run_menu_content_agent`) — valid output structure
+  (price band ordered, fields within length, prep time typed) and that a pizza is
+  slotted into the existing `Pizza` category.
+
+The free **regression tests** in `tests/unit/core/` pin the surrounding plumbing
+(menu prices reach the prompt, prose-wrapped JSON is parsed, garbage falls back,
+multi-turn history is retained, `is_new` is recomputed server-side, fields are
+clamped/coerced). These run with the rest of the unit suite and never call the API.
 
 ### Running Custom Evals
 ```bash
@@ -64,8 +82,9 @@ pytest tests/evals/test_recommendation_quality.py -v
 | Refusal Rate (off-topic) | 100% | ✅ |
 | False Positive Rate | ≤5% | ✅ |
 | Category Diversity | ≥2 | ✅ |
-| Insights grounding (numbers backed by data) | ≥99% | ✅ |
-| Menu `is_new` correctness | 100% | ✅ |
+| Insights grounding — live model (`RUN_AI_EVALS=1`) | ≥80% | ✅ |
+| Insights grounding — fallback (regression) | ≥99% | ✅ |
+| Menu `is_new` correctness (regression) | 100% | ✅ |
 
 ---
 

--- a/backend/tests/evals/conftest.py
+++ b/backend/tests/evals/conftest.py
@@ -136,30 +136,3 @@ def mock_menu_prices(mock_menu) -> List[Dict]:
 def mock_categories() -> List[str]:
     """Existing categories used by the menu content agent."""
     return ["Pizza", "Burgers", "Salads", "Desserts"]
-
-
-def make_mock_deepseek(content: str, capture: List[Dict] = None) -> MagicMock:
-    """
-    Build a mock DeepSeek client whose chat.completions.create returns `content`.
-    If `capture` is provided, each call's kwargs (incl. messages) are appended to
-    it so tests can assert what was actually sent in the prompt.
-    """
-    client = MagicMock()
-
-    async def _create(*args, **kwargs):
-        if capture is not None:
-            capture.append(kwargs)
-        resp = MagicMock()
-        resp.choices = [MagicMock()]
-        resp.choices[0].message.content = content
-        resp.choices[0].finish_reason = "stop"
-        return resp
-
-    client.chat.completions.create = _create
-    return client
-
-
-@pytest.fixture
-def mock_deepseek_factory():
-    """Expose make_mock_deepseek as a fixture for use inside tests."""
-    return make_mock_deepseek

--- a/backend/tests/evals/conftest.py
+++ b/backend/tests/evals/conftest.py
@@ -99,8 +99,67 @@ def mock_deepseek_client(mock_deepseek_vegan_response):
 
 @pytest.fixture(autouse=True)
 def reset_chat_sessions():
-    """Clear chat sessions before each test."""
-    from core.ai import _chat_sessions
+    """Clear chat sessions before each test (both customer and manager agents)."""
+    from core.ai import _chat_sessions, _insights_sessions
     _chat_sessions.clear()
+    _insights_sessions.clear()
     yield
     _chat_sessions.clear()
+    _insights_sessions.clear()
+
+
+# ---------------------------------------------------------------------------
+# Manager-side agents (insights + menu content) — fixtures & helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_report() -> Dict:
+    """Standardized sales report for reproducible insights evaluations."""
+    return load_json("mock_report.json")
+
+
+@pytest.fixture
+def mock_menu_prices(mock_menu) -> List[Dict]:
+    """Menu price list in the shape the insights endpoint passes to the agent."""
+    return [
+        {
+            "name": item["name"],
+            "price": item["price"],
+            "is_available": item.get("is_available", True),
+            "category": item.get("category"),
+        }
+        for item in mock_menu
+    ]
+
+
+@pytest.fixture
+def mock_categories() -> List[str]:
+    """Existing categories used by the menu content agent."""
+    return ["Pizza", "Burgers", "Salads", "Desserts"]
+
+
+def make_mock_deepseek(content: str, capture: List[Dict] = None) -> MagicMock:
+    """
+    Build a mock DeepSeek client whose chat.completions.create returns `content`.
+    If `capture` is provided, each call's kwargs (incl. messages) are appended to
+    it so tests can assert what was actually sent in the prompt.
+    """
+    client = MagicMock()
+
+    async def _create(*args, **kwargs):
+        if capture is not None:
+            capture.append(kwargs)
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = content
+        resp.choices[0].finish_reason = "stop"
+        return resp
+
+    client.chat.completions.create = _create
+    return client
+
+
+@pytest.fixture
+def mock_deepseek_factory():
+    """Expose make_mock_deepseek as a fixture for use inside tests."""
+    return make_mock_deepseek

--- a/backend/tests/evals/data/mock_report.json
+++ b/backend/tests/evals/data/mock_report.json
@@ -1,0 +1,16 @@
+{
+  "start_date": "2026-06-01",
+  "end_date": "2026-06-07",
+  "total_revenue": 4520.0,
+  "total_orders": 128,
+  "average_order_value": 35.31,
+  "top_items": [
+    {"name": "Margherita Pizza", "quantity_sold": 64},
+    {"name": "Classic Cheeseburger", "quantity_sold": 41},
+    {"name": "Caesar Salad", "quantity_sold": 33}
+  ],
+  "revenue_by_day": [
+    {"date": "2026-06-06", "revenue": 2100.0},
+    {"date": "2026-06-07", "revenue": 2420.0}
+  ]
+}

--- a/backend/tests/evals/metrics/__init__.py
+++ b/backend/tests/evals/metrics/__init__.py
@@ -10,10 +10,17 @@ Provides:
 from .relevance import precision_at_k, recall_at_k, ndcg_at_k, calculate_relevance_scores
 from .diversity import category_diversity, tag_diversity, intra_list_diversity
 from .safety import refusal_rate, false_positive_rate, is_refusal, EXPECTED_REFUSAL
+from .grounding import (
+    extract_numbers,
+    unsupported_numbers,
+    grounding_score,
+    report_numbers,
+    is_discount_of,
+)
 
 __all__ = [
     "precision_at_k",
-    "recall_at_k", 
+    "recall_at_k",
     "ndcg_at_k",
     "calculate_relevance_scores",
     "category_diversity",
@@ -23,4 +30,9 @@ __all__ = [
     "false_positive_rate",
     "is_refusal",
     "EXPECTED_REFUSAL",
+    "extract_numbers",
+    "unsupported_numbers",
+    "grounding_score",
+    "report_numbers",
+    "is_discount_of",
 ]

--- a/backend/tests/evals/metrics/grounding.py
+++ b/backend/tests/evals/metrics/grounding.py
@@ -10,13 +10,22 @@ import re
 from typing import Iterable, List, Set
 
 
-def extract_numbers(text: str) -> List[float]:
+_PERCENT_RE = re.compile(r"\d+(?:[.,]\d+)?\s*%")
+
+
+def extract_numbers(text: str, skip_percentages: bool = True) -> List[float]:
     """
     Pull numeric values out of free text. Handles both '35.31' and Romanian
     '35,31' decimals. Pure integers and decimals are returned as floats.
+
+    Percentages ('90%') are derived reasoning, not cited data, so by default they
+    are stripped before extraction (otherwise a correct "peste 90% din venit"
+    would be scored as an unsupported number).
     """
     if not text:
         return []
+    if skip_percentages:
+        text = _PERCENT_RE.sub(" ", text)
     nums: List[float] = []
     for raw in re.findall(r"\d+(?:[.,]\d+)?", text):
         try:
@@ -50,8 +59,23 @@ def grounding_score(text: str, allowed: Iterable[float], tol: float = 0.5) -> fl
     return supported / len(nums)
 
 
+def _add_date_parts(date_str: str, allowed: Set[float]) -> None:
+    """Add year/month/day of a 'YYYY-MM-DD' string so date references count as grounded."""
+    if not isinstance(date_str, str):
+        return
+    for part in date_str.split("-"):
+        try:
+            allowed.add(float(int(part)))
+        except ValueError:
+            continue
+
+
 def report_numbers(report: dict) -> Set[float]:
-    """Collect every figure the agent is allowed to cite from a range report."""
+    """
+    Collect every figure the agent is allowed to cite from a range report —
+    metrics, quantities, daily revenue, AND the date components of the period
+    (a grounded answer naturally says "1-7 iunie 2026", "pe 6 iunie", etc.).
+    """
     allowed: Set[float] = set()
     for key in ("total_revenue", "total_orders", "average_order_value"):
         val = report.get(key)
@@ -65,6 +89,9 @@ def report_numbers(report: dict) -> Set[float]:
         r = d.get("revenue")
         if isinstance(r, (int, float)):
             allowed.add(float(r))
+        _add_date_parts(d.get("date"), allowed)
+    _add_date_parts(report.get("start_date"), allowed)
+    _add_date_parts(report.get("end_date"), allowed)
     return allowed
 
 

--- a/backend/tests/evals/metrics/grounding.py
+++ b/backend/tests/evals/metrics/grounding.py
@@ -1,0 +1,81 @@
+"""
+Grounding / faithfulness metrics for the manager insights agent.
+
+The insights agent must answer ONLY from the sales report + menu prices it is
+given; it must not invent figures. These helpers measure how well a response's
+numbers are supported by the data the agent actually had.
+"""
+
+import re
+from typing import Iterable, List, Set
+
+
+def extract_numbers(text: str) -> List[float]:
+    """
+    Pull numeric values out of free text. Handles both '35.31' and Romanian
+    '35,31' decimals. Pure integers and decimals are returned as floats.
+    """
+    if not text:
+        return []
+    nums: List[float] = []
+    for raw in re.findall(r"\d+(?:[.,]\d+)?", text):
+        try:
+            nums.append(float(raw.replace(",", ".")))
+        except ValueError:
+            continue
+    return nums
+
+
+def _is_supported(value: float, allowed: Iterable[float], tol: float = 0.5) -> bool:
+    """A number is supported if it (approximately) matches any allowed figure."""
+    return any(abs(value - a) <= tol for a in allowed)
+
+
+def unsupported_numbers(text: str, allowed: Iterable[float], tol: float = 0.5) -> List[float]:
+    """Return the numbers in `text` that are NOT backed by any allowed figure."""
+    allowed = list(allowed)
+    return [n for n in extract_numbers(text) if not _is_supported(n, allowed, tol)]
+
+
+def grounding_score(text: str, allowed: Iterable[float], tol: float = 0.5) -> float:
+    """
+    Fraction of numbers in `text` that are supported by `allowed` (1.0 if the
+    text contains no numbers at all — nothing to hallucinate).
+    """
+    nums = extract_numbers(text)
+    if not nums:
+        return 1.0
+    allowed = list(allowed)
+    supported = sum(1 for n in nums if _is_supported(n, allowed, tol))
+    return supported / len(nums)
+
+
+def report_numbers(report: dict) -> Set[float]:
+    """Collect every figure the agent is allowed to cite from a range report."""
+    allowed: Set[float] = set()
+    for key in ("total_revenue", "total_orders", "average_order_value"):
+        val = report.get(key)
+        if isinstance(val, (int, float)):
+            allowed.add(float(val))
+    for t in report.get("top_items", []):
+        q = t.get("quantity_sold")
+        if isinstance(q, (int, float)):
+            allowed.add(float(q))
+    for d in report.get("revenue_by_day", []):
+        r = d.get("revenue")
+        if isinstance(r, (int, float)):
+            allowed.add(float(r))
+    return allowed
+
+
+def is_discount_of(suggested: float, base: float, min_pct: float = 0.05, max_pct: float = 0.40) -> bool:
+    """
+    True if `suggested` is a plausible discounted price of `base` — i.e. a
+    reduction between min_pct and max_pct. Used to check happy-hour suggestions
+    are derived from the real menu price, not invented.
+    """
+    if base <= 0:
+        return False
+    lowest = base * (1 - max_pct)
+    highest = base * (1 - min_pct)
+    return lowest - 1e-6 <= suggested <= highest + 1e-6

--- a/backend/tests/evals/test_insights_quality.py
+++ b/backend/tests/evals/test_insights_quality.py
@@ -1,0 +1,190 @@
+"""
+Manager Insights Agent Evaluation Tests
+
+Evaluates the conversational sales-analysis agent (run_manager_insights_agent):
+- Grounding/faithfulness: cites only figures present in the report (no hallucination)
+- Pricing: happy-hour/discount suggestions are derived from real menu prices
+  (regression for the bug where the agent had no prices and answered generically)
+- Robustness: parses JSON wrapped in prose; falls back safely on garbage
+- Multi-turn: conversation history is retained per session
+- Fallback: deterministic summary when AI is disabled
+
+All tests are deterministic and make NO real API calls (the DeepSeek client is
+mocked or fallback mode is forced).
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from core.ai import run_manager_insights_agent, _format_report_for_prompt
+from tests.evals.conftest import make_mock_deepseek
+from tests.evals.metrics import grounding_score, report_numbers, is_discount_of
+
+
+GROUNDING_TARGET = 0.99  # insights must not invent figures
+
+
+@contextmanager
+def mocked_ai(content: str, capture=None):
+    """Force the AI path on and route it through a mock DeepSeek client."""
+    with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.settings.DEEPSEEK_API_KEY", "test-key"), \
+         patch("core.ai.settings.DEEPSEEK_MODEL", "deepseek-test"), \
+         patch("core.ai.get_deepseek_client", return_value=make_mock_deepseek(content, capture)):
+        yield
+
+
+class TestInsightsGrounding:
+    """The agent must answer only from the data it was given."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_numbers_are_grounded(self, mock_report):
+        """Fallback summary cites only figures present in the report."""
+        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
+            result = await run_manager_insights_agent(
+                message="Cum au fost vânzările?",
+                session_id="ins-fallback-001",
+                report_data=mock_report,
+            )
+
+        assert result["agent"] == "fallback"
+        allowed = report_numbers(mock_report)
+        text = result["response_text"] + " " + " ".join(result["insights"])
+        score = grounding_score(text, allowed)
+        assert score >= GROUNDING_TARGET, f"Fallback grounding {score:.2f} < {GROUNDING_TARGET}"
+
+    @pytest.mark.asyncio
+    async def test_ai_response_numbers_are_grounded(self, mock_report, mock_menu_prices):
+        """A well-behaved AI answer that cites report figures scores fully grounded."""
+        content = json.dumps({
+            "response_text": "Venit total 4520.0 RON din 128 comenzi, valoare medie 35.31 RON.",
+            "insights": ["Margherita Pizza s-a vândut în 64 de porții."],
+            "follow_up_question": None,
+        })
+        with mocked_ai(content):
+            result = await run_manager_insights_agent(
+                message="Rezumă perioada",
+                session_id="ins-ground-001",
+                report_data=mock_report,
+                menu_items=mock_menu_prices,
+            )
+
+        allowed = report_numbers(mock_report)
+        text = result["response_text"] + " " + " ".join(result["insights"])
+        assert grounding_score(text, allowed) >= GROUNDING_TARGET
+
+
+class TestInsightsPricing:
+    """Regression: agent must have menu prices and use them for price suggestions."""
+
+    @pytest.mark.asyncio
+    async def test_menu_prices_reach_the_prompt(self, mock_report, mock_menu_prices):
+        """Every menu item name + price must appear in the system prompt."""
+        capture = []
+        content = json.dumps({"response_text": "ok", "insights": [], "follow_up_question": None})
+        with mocked_ai(content, capture=capture):
+            await run_manager_insights_agent(
+                message="Ce preț de happy hour la Margherita Pizza?",
+                session_id="ins-price-001",
+                report_data=mock_report,
+                menu_items=mock_menu_prices,
+            )
+
+        system_prompt = capture[0]["messages"][0]["content"]
+        for item in mock_menu_prices:
+            assert item["name"] in system_prompt, f"{item['name']} missing from prompt"
+            assert str(item["price"]) in system_prompt, f"price of {item['name']} missing"
+
+    @pytest.mark.asyncio
+    async def test_happy_hour_price_is_discount_of_real_price(self, mock_report, mock_menu_prices):
+        """A suggested happy-hour price should be a plausible discount of the menu price."""
+        pizza = next(i for i in mock_menu_prices if i["name"] == "Margherita Pizza")
+        base = pizza["price"]  # 35.0
+        suggested = round(base * 0.8, 2)  # 20% off → 28.0
+        content = json.dumps({
+            "response_text": f"Pentru happy hour la Margherita Pizza propun {suggested} RON (−20% de la {base} RON).",
+            "insights": [f"Reducere 20% la Margherita Pizza: {suggested} RON."],
+            "follow_up_question": None,
+        })
+        with mocked_ai(content):
+            result = await run_manager_insights_agent(
+                message="Sugerează un preț de happy hour pentru Margherita Pizza",
+                session_id="ins-price-002",
+                report_data=mock_report,
+                menu_items=mock_menu_prices,
+            )
+
+        assert is_discount_of(suggested, base), "suggested price not a plausible discount"
+        assert str(suggested) in result["response_text"]
+
+
+class TestInsightsRobustness:
+    """Parsing resilience and safe degradation."""
+
+    @pytest.mark.asyncio
+    async def test_prose_wrapped_json_is_parsed(self, mock_report):
+        """JSON surrounded by prose is still extracted (not dumped to fallback)."""
+        content = (
+            "Sigur, iată analiza:\n```json\n"
+            + json.dumps({"response_text": "Venit bun.", "insights": ["ok"], "follow_up_question": None})
+            + "\n```\nSper că ajută!"
+        )
+        with mocked_ai(content):
+            result = await run_manager_insights_agent(
+                message="analiză",
+                session_id="ins-robust-001",
+                report_data=mock_report,
+            )
+
+        assert result["agent"] != "fallback"
+        assert result["response_text"] == "Venit bun."
+
+    @pytest.mark.asyncio
+    async def test_unparseable_output_falls_back(self, mock_report):
+        """Non-JSON model output degrades to the deterministic summary."""
+        with mocked_ai("îmi pare rău, nu am înțeles"):
+            result = await run_manager_insights_agent(
+                message="analiză",
+                session_id="ins-robust-002",
+                report_data=mock_report,
+            )
+
+        assert result["agent"] == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_history_retained(self, mock_report):
+        """Second turn in a session sends the first turn back as context."""
+        capture = []
+        content = json.dumps({"response_text": "răspuns", "insights": [], "follow_up_question": None})
+        with mocked_ai(content, capture=capture):
+            sid = "ins-history-001"
+            await run_manager_insights_agent("prima întrebare", sid, mock_report)
+            await run_manager_insights_agent("a doua întrebare", sid, mock_report)
+
+        second_call_messages = capture[1]["messages"]
+        contents = [m["content"] for m in second_call_messages]
+        assert "prima întrebare" in contents, "first user turn not replayed on turn 2"
+        assert "răspuns" in contents, "first assistant turn not replayed on turn 2"
+
+
+class TestInsightsStructure:
+    """Response shape contract used by the API/frontend."""
+
+    @pytest.mark.asyncio
+    async def test_response_fields_present(self, mock_report):
+        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
+            result = await run_manager_insights_agent(
+                message="rezumat", session_id="ins-struct-001", report_data=mock_report
+            )
+        for field in ("response_text", "insights", "follow_up_question", "session_id", "agent"):
+            assert field in result
+        assert isinstance(result["insights"], list)
+
+    def test_report_formatter_includes_key_figures(self, mock_report):
+        text = _format_report_for_prompt(mock_report)
+        assert "4520.0" in text
+        assert "128" in text
+        assert "Margherita Pizza" in text

--- a/backend/tests/evals/test_insights_quality.py
+++ b/backend/tests/evals/test_insights_quality.py
@@ -1,190 +1,96 @@
 """
-Manager Insights Agent Evaluation Tests
+Manager Insights Agent — REAL Evals (consume API tokens)
 
-Evaluates the conversational sales-analysis agent (run_manager_insights_agent):
-- Grounding/faithfulness: cites only figures present in the report (no hallucination)
-- Pricing: happy-hour/discount suggestions are derived from real menu prices
-  (regression for the bug where the agent had no prices and answered generically)
-- Robustness: parses JSON wrapped in prose; falls back safely on garbage
-- Multi-turn: conversation history is retained per session
-- Fallback: deterministic summary when AI is disabled
+These call the LIVE DeepSeek model and score its actual output. They are OPT-IN:
+they only run when RUN_AI_EVALS=1 (and a key is configured), so normal test runs
+and CI stay free. Run them deliberately when you want to measure quality:
 
-All tests are deterministic and make NO real API calls (the DeepSeek client is
-mocked or fallback mode is forced).
+    RUN_AI_EVALS=1 pytest tests/evals/test_insights_quality.py -v -s
+
+Deterministic regression tests for the same agent's plumbing (parsing, fallback,
+prompt assembly) live in tests/unit/core/test_insights_agent.py and run for free.
 """
 
-import json
-from contextlib import contextmanager
-from unittest.mock import patch
-
+import os
 import pytest
 
-from core.ai import run_manager_insights_agent, _format_report_for_prompt
-from tests.evals.conftest import make_mock_deepseek
-from tests.evals.metrics import grounding_score, report_numbers, is_discount_of
+from core.config import settings
+from core.ai import run_manager_insights_agent
+from tests.evals.metrics import (
+    grounding_score,
+    report_numbers,
+    extract_numbers,
+    is_discount_of,
+)
 
 
-GROUNDING_TARGET = 0.99  # insights must not invent figures
+def _evals_enabled() -> bool:
+    return bool(os.getenv("RUN_AI_EVALS")) and settings.USE_AI_RECOMMENDATIONS and bool(settings.DEEPSEEK_API_KEY)
 
 
-@contextmanager
-def mocked_ai(content: str, capture=None):
-    """Force the AI path on and route it through a mock DeepSeek client."""
-    with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
-         patch("core.ai.settings.DEEPSEEK_API_KEY", "test-key"), \
-         patch("core.ai.settings.DEEPSEEK_MODEL", "deepseek-test"), \
-         patch("core.ai.get_deepseek_client", return_value=make_mock_deepseek(content, capture)):
-        yield
+pytestmark = [
+    pytest.mark.eval,
+    pytest.mark.skipif(
+        not _evals_enabled(),
+        reason="Real AI eval — set RUN_AI_EVALS=1 and configure DEEPSEEK_API_KEY to run (consumes tokens).",
+    ),
+]
 
 
-class TestInsightsGrounding:
-    """The agent must answer only from the data it was given."""
+# Relaxed targets — real model output is non-deterministic.
+GROUNDING_TARGET = 0.80
 
+
+class TestInsightsGroundingReal:
     @pytest.mark.asyncio
-    async def test_fallback_numbers_are_grounded(self, mock_report):
-        """Fallback summary cites only figures present in the report."""
-        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
-            result = await run_manager_insights_agent(
-                message="Cum au fost vânzările?",
-                session_id="ins-fallback-001",
-                report_data=mock_report,
-            )
+    async def test_summary_is_grounded(self, mock_report, mock_menu_prices):
+        """A summary request should cite figures backed by the report, not invented ones."""
+        result = await run_manager_insights_agent(
+            message="Rezumă pe scurt vânzările din această perioadă.",
+            session_id="eval-ins-ground",
+            report_data=mock_report,
+            menu_items=mock_menu_prices,
+        )
+        assert result["agent"] != "fallback", "model did not answer (fallback) — check API/key"
 
-        assert result["agent"] == "fallback"
         allowed = report_numbers(mock_report)
         text = result["response_text"] + " " + " ".join(result["insights"])
         score = grounding_score(text, allowed)
-        assert score >= GROUNDING_TARGET, f"Fallback grounding {score:.2f} < {GROUNDING_TARGET}"
+        print(f"\n[insights] grounding score: {score:.2f}")
+        assert score >= GROUNDING_TARGET, f"grounding {score:.2f} < {GROUNDING_TARGET}: {text}"
 
     @pytest.mark.asyncio
-    async def test_ai_response_numbers_are_grounded(self, mock_report, mock_menu_prices):
-        """A well-behaved AI answer that cites report figures scores fully grounded."""
-        content = json.dumps({
-            "response_text": "Venit total 4520.0 RON din 128 comenzi, valoare medie 35.31 RON.",
-            "insights": ["Margherita Pizza s-a vândut în 64 de porții."],
-            "follow_up_question": None,
-        })
-        with mocked_ai(content):
-            result = await run_manager_insights_agent(
-                message="Rezumă perioada",
-                session_id="ins-ground-001",
-                report_data=mock_report,
-                menu_items=mock_menu_prices,
-            )
-
-        allowed = report_numbers(mock_report)
-        text = result["response_text"] + " " + " ".join(result["insights"])
-        assert grounding_score(text, allowed) >= GROUNDING_TARGET
+    async def test_missing_figure_is_not_invented(self, mock_report):
+        """Asked about data it doesn't have (no menu prices given), it should not fabricate a price."""
+        result = await run_manager_insights_agent(
+            message="Care este prețul exact al unei Margherita Pizza?",
+            session_id="eval-ins-missing",
+            report_data=mock_report,
+            menu_items=None,  # deliberately withhold prices
+        )
+        # The report carries no per-item price, so a confident "35 RON" would be a hallucination.
+        # We don't hard-pin wording; we check it doesn't assert a specific RON price.
+        text = result["response_text"].lower()
+        hedged = any(k in text for k in ["nu am", "nu dețin", "nu este", "nu sunt", "lipsesc", "nu apar"])
+        print(f"\n[insights] missing-data reply: {result['response_text'][:160]}")
+        assert hedged or "ron" not in text, f"may have invented a price: {result['response_text']}"
 
 
-class TestInsightsPricing:
-    """Regression: agent must have menu prices and use them for price suggestions."""
-
+class TestInsightsPricingReal:
     @pytest.mark.asyncio
-    async def test_menu_prices_reach_the_prompt(self, mock_report, mock_menu_prices):
-        """Every menu item name + price must appear in the system prompt."""
-        capture = []
-        content = json.dumps({"response_text": "ok", "insights": [], "follow_up_question": None})
-        with mocked_ai(content, capture=capture):
-            await run_manager_insights_agent(
-                message="Ce preț de happy hour la Margherita Pizza?",
-                session_id="ins-price-001",
-                report_data=mock_report,
-                menu_items=mock_menu_prices,
-            )
-
-        system_prompt = capture[0]["messages"][0]["content"]
-        for item in mock_menu_prices:
-            assert item["name"] in system_prompt, f"{item['name']} missing from prompt"
-            assert str(item["price"]) in system_prompt, f"price of {item['name']} missing"
-
-    @pytest.mark.asyncio
-    async def test_happy_hour_price_is_discount_of_real_price(self, mock_report, mock_menu_prices):
-        """A suggested happy-hour price should be a plausible discount of the menu price."""
+    async def test_happy_hour_derives_from_real_price(self, mock_report, mock_menu_prices):
+        """Happy-hour suggestion for a known item should relate to its real menu price."""
         pizza = next(i for i in mock_menu_prices if i["name"] == "Margherita Pizza")
         base = pizza["price"]  # 35.0
-        suggested = round(base * 0.8, 2)  # 20% off → 28.0
-        content = json.dumps({
-            "response_text": f"Pentru happy hour la Margherita Pizza propun {suggested} RON (−20% de la {base} RON).",
-            "insights": [f"Reducere 20% la Margherita Pizza: {suggested} RON."],
-            "follow_up_question": None,
-        })
-        with mocked_ai(content):
-            result = await run_manager_insights_agent(
-                message="Sugerează un preț de happy hour pentru Margherita Pizza",
-                session_id="ins-price-002",
-                report_data=mock_report,
-                menu_items=mock_menu_prices,
-            )
-
-        assert is_discount_of(suggested, base), "suggested price not a plausible discount"
-        assert str(suggested) in result["response_text"]
-
-
-class TestInsightsRobustness:
-    """Parsing resilience and safe degradation."""
-
-    @pytest.mark.asyncio
-    async def test_prose_wrapped_json_is_parsed(self, mock_report):
-        """JSON surrounded by prose is still extracted (not dumped to fallback)."""
-        content = (
-            "Sigur, iată analiza:\n```json\n"
-            + json.dumps({"response_text": "Venit bun.", "insights": ["ok"], "follow_up_question": None})
-            + "\n```\nSper că ajută!"
+        result = await run_manager_insights_agent(
+            message="Ce preț de happy hour ai sugera pentru Margherita Pizza? Dă o cifră concretă.",
+            session_id="eval-ins-happyhour",
+            report_data=mock_report,
+            menu_items=mock_menu_prices,
         )
-        with mocked_ai(content):
-            result = await run_manager_insights_agent(
-                message="analiză",
-                session_id="ins-robust-001",
-                report_data=mock_report,
-            )
-
         assert result["agent"] != "fallback"
-        assert result["response_text"] == "Venit bun."
-
-    @pytest.mark.asyncio
-    async def test_unparseable_output_falls_back(self, mock_report):
-        """Non-JSON model output degrades to the deterministic summary."""
-        with mocked_ai("îmi pare rău, nu am înțeles"):
-            result = await run_manager_insights_agent(
-                message="analiză",
-                session_id="ins-robust-002",
-                report_data=mock_report,
-            )
-
-        assert result["agent"] == "fallback"
-
-    @pytest.mark.asyncio
-    async def test_multi_turn_history_retained(self, mock_report):
-        """Second turn in a session sends the first turn back as context."""
-        capture = []
-        content = json.dumps({"response_text": "răspuns", "insights": [], "follow_up_question": None})
-        with mocked_ai(content, capture=capture):
-            sid = "ins-history-001"
-            await run_manager_insights_agent("prima întrebare", sid, mock_report)
-            await run_manager_insights_agent("a doua întrebare", sid, mock_report)
-
-        second_call_messages = capture[1]["messages"]
-        contents = [m["content"] for m in second_call_messages]
-        assert "prima întrebare" in contents, "first user turn not replayed on turn 2"
-        assert "răspuns" in contents, "first assistant turn not replayed on turn 2"
-
-
-class TestInsightsStructure:
-    """Response shape contract used by the API/frontend."""
-
-    @pytest.mark.asyncio
-    async def test_response_fields_present(self, mock_report):
-        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
-            result = await run_manager_insights_agent(
-                message="rezumat", session_id="ins-struct-001", report_data=mock_report
-            )
-        for field in ("response_text", "insights", "follow_up_question", "session_id", "agent"):
-            assert field in result
-        assert isinstance(result["insights"], list)
-
-    def test_report_formatter_includes_key_figures(self, mock_report):
-        text = _format_report_for_prompt(mock_report)
-        assert "4520.0" in text
-        assert "128" in text
-        assert "Margherita Pizza" in text
+        nums = extract_numbers(result["response_text"] + " " + " ".join(result["insights"]))
+        print(f"\n[insights] base={base} numbers={nums}")
+        # At least one number should be the base price or a plausible discount of it.
+        ok = any(abs(n - base) < 0.5 or is_discount_of(n, base) for n in nums)
+        assert ok, f"no number related to real price {base}: {nums}"

--- a/backend/tests/evals/test_menu_content_quality.py
+++ b/backend/tests/evals/test_menu_content_quality.py
@@ -1,0 +1,189 @@
+"""
+Menu Content Generator Agent Evaluation Tests
+
+Evaluates run_menu_content_agent (single-shot generation of description, dietary
+tags, suggested category, price band, prep time for a new menu item).
+
+Focus is the server-side validation in _finalize, which is the trust boundary:
+- is_new is recomputed against the REAL category list (model's flag is ignored)
+- fields are length-clamped and type-coerced
+- malformed model output is tolerated, not crashed on
+- fallback template when AI is disabled
+
+All deterministic, NO real API calls.
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from core.ai import run_menu_content_agent
+from tests.evals.conftest import make_mock_deepseek
+
+
+@contextmanager
+def mocked_ai(content: str, capture=None):
+    with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.settings.DEEPSEEK_API_KEY", "test-key"), \
+         patch("core.ai.settings.DEEPSEEK_MODEL", "deepseek-test"), \
+         patch("core.ai.get_deepseek_client", return_value=make_mock_deepseek(content, capture)):
+        yield
+
+
+class TestCategoryValidation:
+    """is_new is the server's call, not the model's."""
+
+    @pytest.mark.asyncio
+    async def test_existing_category_forces_is_new_false(self, mock_categories):
+        """Model claims a brand-new category that already exists → corrected to is_new=False."""
+        content = json.dumps({
+            "description": "Pizza picantă cu salam.",
+            "dietary_tags": "",
+            "suggested_category": {"name": "pizza", "is_new": True},  # wrong + wrong case
+            "price_band": {"min": 30.0, "max": 40.0},
+            "prep_time_minutes": 15,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(
+                name="Pizza Diavola", ingredients="salam, ardei iute",
+                existing_categories=mock_categories,
+            )
+
+        assert result["suggested_category"]["is_new"] is False
+        assert result["suggested_category"]["name"] == "Pizza"  # normalized to existing casing
+
+    @pytest.mark.asyncio
+    async def test_new_category_forces_is_new_true(self, mock_categories):
+        """Model claims existing for a category that's actually new → corrected to is_new=True."""
+        content = json.dumps({
+            "description": "Tapas spaniole de partajat.",
+            "dietary_tags": "vegetarian",
+            "suggested_category": {"name": "Tapas", "is_new": False},
+            "price_band": {"min": 20.0, "max": 28.0},
+            "prep_time_minutes": 12,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(
+                name="Patatas Bravas", ingredients="cartofi, sos picant",
+                existing_categories=mock_categories,
+            )
+
+        assert result["suggested_category"]["is_new"] is True
+        assert result["suggested_category"]["name"] == "Tapas"
+
+    @pytest.mark.asyncio
+    async def test_category_as_plain_string_tolerated(self, mock_categories):
+        """Model returns suggested_category as a string instead of an object."""
+        content = json.dumps({
+            "description": "Desert cu ciocolată.",
+            "dietary_tags": "vegetarian",
+            "suggested_category": "Desserts",
+            "price_band": {"min": 18.0, "max": 24.0},
+            "prep_time_minutes": 10,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(
+                name="Lava Cake", existing_categories=mock_categories,
+            )
+
+        assert result["suggested_category"]["name"] == "Desserts"
+        assert result["suggested_category"]["is_new"] is False
+
+
+class TestFieldSanitization:
+    """Output fields are clamped/coerced regardless of what the model returns."""
+
+    @pytest.mark.asyncio
+    async def test_long_fields_are_truncated(self, mock_categories):
+        content = json.dumps({
+            "description": "x" * 900,
+            "dietary_tags": "y" * 400,
+            "suggested_category": {"name": "Pizza", "is_new": False},
+            "price_band": {"min": 30.0, "max": 40.0},
+            "prep_time_minutes": 15,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
+
+        assert len(result["description"]) <= 500
+        assert len(result["dietary_tags"]) <= 255
+
+    @pytest.mark.asyncio
+    async def test_price_band_coerced_and_rounded(self, mock_categories):
+        content = json.dumps({
+            "description": "ok",
+            "dietary_tags": "",
+            "suggested_category": {"name": "Pizza", "is_new": False},
+            "price_band": {"min": "29.999", "max": "41.234"},  # strings
+            "prep_time_minutes": 15,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
+
+        assert result["price_band"]["min"] == 30.0
+        assert result["price_band"]["max"] == 41.23
+
+    @pytest.mark.asyncio
+    async def test_missing_or_invalid_price_band_defaults(self, mock_categories):
+        content = json.dumps({
+            "description": "ok",
+            "dietary_tags": "",
+            "suggested_category": {"name": "Pizza", "is_new": False},
+            "price_band": "necunoscut",  # invalid type
+            "prep_time_minutes": "nu știu",  # invalid → None
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
+
+        assert result["price_band"] == {"min": 0.0, "max": 0.0}
+        assert result["prep_time_minutes"] is None
+
+
+class TestFallback:
+    """Deterministic template when AI is unavailable."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_ai_disabled(self, mock_categories):
+        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
+            result = await run_menu_content_agent(
+                name="Bruschette", ingredients="roșii, busuioc",
+                existing_categories=mock_categories,
+            )
+
+        assert result["agent"] == "fallback"
+        assert result["description"]  # non-empty
+        assert "Bruschette" in result["description"]
+
+    @pytest.mark.asyncio
+    async def test_empty_description_falls_back(self, mock_categories):
+        """Model returns no usable description → fallback template."""
+        content = json.dumps({"description": "", "suggested_category": {"name": "Pizza"}})
+        with mocked_ai(content):
+            result = await run_menu_content_agent(
+                name="Mystery", ingredients="x", existing_categories=mock_categories,
+            )
+
+        assert result["agent"] == "fallback"
+
+
+class TestStructure:
+    """Response shape contract."""
+
+    @pytest.mark.asyncio
+    async def test_response_fields_present(self, mock_categories):
+        content = json.dumps({
+            "description": "ok",
+            "dietary_tags": "vegetarian",
+            "suggested_category": {"name": "Pizza", "is_new": False},
+            "price_band": {"min": 30.0, "max": 40.0},
+            "prep_time_minutes": 15,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
+
+        for field in ("description", "dietary_tags", "suggested_category", "price_band", "prep_time_minutes", "agent"):
+            assert field in result
+        assert set(result["suggested_category"].keys()) == {"name", "is_new"}
+        assert set(result["price_band"].keys()) == {"min", "max"}

--- a/backend/tests/evals/test_menu_content_quality.py
+++ b/backend/tests/evals/test_menu_content_quality.py
@@ -1,189 +1,70 @@
 """
-Menu Content Generator Agent Evaluation Tests
+Menu Content Generator Agent — REAL Evals (consume API tokens)
 
-Evaluates run_menu_content_agent (single-shot generation of description, dietary
-tags, suggested category, price band, prep time for a new menu item).
+Calls the LIVE model to generate content for a new menu item and scores the
+result. OPT-IN via RUN_AI_EVALS=1:
 
-Focus is the server-side validation in _finalize, which is the trust boundary:
-- is_new is recomputed against the REAL category list (model's flag is ignored)
-- fields are length-clamped and type-coerced
-- malformed model output is tolerated, not crashed on
-- fallback template when AI is disabled
+    RUN_AI_EVALS=1 pytest tests/evals/test_menu_content_quality.py -v -s
 
-All deterministic, NO real API calls.
+Deterministic regression tests for the validation boundary (is_new recompute,
+field clamping, fallback) live in tests/unit/core/test_menu_content_agent.py.
 """
 
-import json
-from contextlib import contextmanager
-from unittest.mock import patch
-
+import os
 import pytest
 
+from core.config import settings
 from core.ai import run_menu_content_agent
-from tests.evals.conftest import make_mock_deepseek
 
 
-@contextmanager
-def mocked_ai(content: str, capture=None):
-    with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
-         patch("core.ai.settings.DEEPSEEK_API_KEY", "test-key"), \
-         patch("core.ai.settings.DEEPSEEK_MODEL", "deepseek-test"), \
-         patch("core.ai.get_deepseek_client", return_value=make_mock_deepseek(content, capture)):
-        yield
+def _evals_enabled() -> bool:
+    return bool(os.getenv("RUN_AI_EVALS")) and settings.USE_AI_RECOMMENDATIONS and bool(settings.DEEPSEEK_API_KEY)
 
 
-class TestCategoryValidation:
-    """is_new is the server's call, not the model's."""
+pytestmark = [
+    pytest.mark.eval,
+    pytest.mark.skipif(
+        not _evals_enabled(),
+        reason="Real AI eval — set RUN_AI_EVALS=1 and configure DEEPSEEK_API_KEY to run (consumes tokens).",
+    ),
+]
 
+
+class TestMenuContentReal:
     @pytest.mark.asyncio
-    async def test_existing_category_forces_is_new_false(self, mock_categories):
-        """Model claims a brand-new category that already exists → corrected to is_new=False."""
-        content = json.dumps({
-            "description": "Pizza picantă cu salam.",
-            "dietary_tags": "",
-            "suggested_category": {"name": "pizza", "is_new": True},  # wrong + wrong case
-            "price_band": {"min": 30.0, "max": 40.0},
-            "prep_time_minutes": 15,
-        })
-        with mocked_ai(content):
-            result = await run_menu_content_agent(
-                name="Pizza Diavola", ingredients="salam, ardei iute",
-                existing_categories=mock_categories,
-            )
+    async def test_generates_valid_structure(self, mock_categories):
+        """Real generation must satisfy the field contract used by the menu form."""
+        result = await run_menu_content_agent(
+            name="Pizza Diavola",
+            ingredients="sos de roșii, mozzarella, salam picant, ardei iute",
+            existing_categories=mock_categories,
+        )
+        assert result["agent"] != "fallback", "model did not answer (fallback) — check API/key"
 
-        assert result["suggested_category"]["is_new"] is False
-        assert result["suggested_category"]["name"] == "Pizza"  # normalized to existing casing
-
-    @pytest.mark.asyncio
-    async def test_new_category_forces_is_new_true(self, mock_categories):
-        """Model claims existing for a category that's actually new → corrected to is_new=True."""
-        content = json.dumps({
-            "description": "Tapas spaniole de partajat.",
-            "dietary_tags": "vegetarian",
-            "suggested_category": {"name": "Tapas", "is_new": False},
-            "price_band": {"min": 20.0, "max": 28.0},
-            "prep_time_minutes": 12,
-        })
-        with mocked_ai(content):
-            result = await run_menu_content_agent(
-                name="Patatas Bravas", ingredients="cartofi, sos picant",
-                existing_categories=mock_categories,
-            )
-
-        assert result["suggested_category"]["is_new"] is True
-        assert result["suggested_category"]["name"] == "Tapas"
-
-    @pytest.mark.asyncio
-    async def test_category_as_plain_string_tolerated(self, mock_categories):
-        """Model returns suggested_category as a string instead of an object."""
-        content = json.dumps({
-            "description": "Desert cu ciocolată.",
-            "dietary_tags": "vegetarian",
-            "suggested_category": "Desserts",
-            "price_band": {"min": 18.0, "max": 24.0},
-            "prep_time_minutes": 10,
-        })
-        with mocked_ai(content):
-            result = await run_menu_content_agent(
-                name="Lava Cake", existing_categories=mock_categories,
-            )
-
-        assert result["suggested_category"]["name"] == "Desserts"
-        assert result["suggested_category"]["is_new"] is False
-
-
-class TestFieldSanitization:
-    """Output fields are clamped/coerced regardless of what the model returns."""
-
-    @pytest.mark.asyncio
-    async def test_long_fields_are_truncated(self, mock_categories):
-        content = json.dumps({
-            "description": "x" * 900,
-            "dietary_tags": "y" * 400,
-            "suggested_category": {"name": "Pizza", "is_new": False},
-            "price_band": {"min": 30.0, "max": 40.0},
-            "prep_time_minutes": 15,
-        })
-        with mocked_ai(content):
-            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
-
-        assert len(result["description"]) <= 500
+        assert 0 < len(result["description"]) <= 500
         assert len(result["dietary_tags"]) <= 255
 
-    @pytest.mark.asyncio
-    async def test_price_band_coerced_and_rounded(self, mock_categories):
-        content = json.dumps({
-            "description": "ok",
-            "dietary_tags": "",
-            "suggested_category": {"name": "Pizza", "is_new": False},
-            "price_band": {"min": "29.999", "max": "41.234"},  # strings
-            "prep_time_minutes": 15,
-        })
-        with mocked_ai(content):
-            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
+        band = result["price_band"]
+        assert band["min"] >= 0 and band["max"] >= 0
+        assert band["min"] <= band["max"], f"price band inverted: {band}"
 
-        assert result["price_band"]["min"] == 30.0
-        assert result["price_band"]["max"] == 41.23
+        prep = result["prep_time_minutes"]
+        assert prep is None or (isinstance(prep, int) and prep >= 0)
+
+        cat = result["suggested_category"]
+        assert cat["name"], "empty category name"
+        print(f"\n[menu] desc[:80]={result['description'][:80]!r} band={band} cat={cat}")
 
     @pytest.mark.asyncio
-    async def test_missing_or_invalid_price_band_defaults(self, mock_categories):
-        content = json.dumps({
-            "description": "ok",
-            "dietary_tags": "",
-            "suggested_category": {"name": "Pizza", "is_new": False},
-            "price_band": "necunoscut",  # invalid type
-            "prep_time_minutes": "nu știu",  # invalid → None
-        })
-        with mocked_ai(content):
-            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
-
-        assert result["price_band"] == {"min": 0.0, "max": 0.0}
-        assert result["prep_time_minutes"] is None
-
-
-class TestFallback:
-    """Deterministic template when AI is unavailable."""
-
-    @pytest.mark.asyncio
-    async def test_fallback_when_ai_disabled(self, mock_categories):
-        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
-            result = await run_menu_content_agent(
-                name="Bruschette", ingredients="roșii, busuioc",
-                existing_categories=mock_categories,
-            )
-
-        assert result["agent"] == "fallback"
-        assert result["description"]  # non-empty
-        assert "Bruschette" in result["description"]
-
-    @pytest.mark.asyncio
-    async def test_empty_description_falls_back(self, mock_categories):
-        """Model returns no usable description → fallback template."""
-        content = json.dumps({"description": "", "suggested_category": {"name": "Pizza"}})
-        with mocked_ai(content):
-            result = await run_menu_content_agent(
-                name="Mystery", ingredients="x", existing_categories=mock_categories,
-            )
-
-        assert result["agent"] == "fallback"
-
-
-class TestStructure:
-    """Response shape contract."""
-
-    @pytest.mark.asyncio
-    async def test_response_fields_present(self, mock_categories):
-        content = json.dumps({
-            "description": "ok",
-            "dietary_tags": "vegetarian",
-            "suggested_category": {"name": "Pizza", "is_new": False},
-            "price_band": {"min": 30.0, "max": 40.0},
-            "prep_time_minutes": 15,
-        })
-        with mocked_ai(content):
-            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
-
-        for field in ("description", "dietary_tags", "suggested_category", "price_band", "prep_time_minutes", "agent"):
-            assert field in result
-        assert set(result["suggested_category"].keys()) == {"name", "is_new"}
-        assert set(result["price_band"].keys()) == {"min", "max"}
+    async def test_pizza_maps_to_existing_category(self, mock_categories):
+        """A pizza should be slotted into the existing 'Pizza' category, not a new one."""
+        result = await run_menu_content_agent(
+            name="Pizza Quattro Formaggi",
+            ingredients="mozzarella, gorgonzola, parmezan, provolone",
+            existing_categories=mock_categories,
+        )
+        assert result["agent"] != "fallback"
+        cat = result["suggested_category"]
+        print(f"\n[menu] suggested category: {cat}")
+        assert cat["name"].lower() == "pizza", f"expected existing 'Pizza', got {cat}"
+        assert cat["is_new"] is False

--- a/backend/tests/unit/api/test_insights.py
+++ b/backend/tests/unit/api/test_insights.py
@@ -1,0 +1,84 @@
+"""
+Tests for the Manager Analytics (insights) AI agent endpoints.
+Covers: Manager-only access, rejection of other roles / no token,
+fallback response shape (no AI configured), and the clear endpoint.
+"""
+
+import pytest
+from unittest.mock import patch
+from main import app
+from models.user import User, UserRole
+from core.security import get_current_user
+
+
+@pytest.fixture
+def manager_client(client):
+    """client (real SQLite session) + authenticated Manager."""
+    def override_get_current_user():
+        return User(id=1, email="manager@test.com", name="Mgr", role=UserRole.manager,
+                    hashed_password="pw", phone="22233344")
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    yield client
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+def waiter_client(client):
+    def override_get_current_user():
+        return User(id=2, email="waiter@test.com", name="Wtr", role=UserRole.waiter,
+                    hashed_password="pw", phone="33344455")
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    yield client
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+class TestInsightsAuth:
+    def test_chat_requires_token(self, client):
+        resp = client.post("/api/insights/chat", json={"message": "Cum merg vânzările?"})
+        assert resp.status_code == 401
+
+    def test_chat_rejects_non_manager(self, waiter_client):
+        resp = waiter_client.post("/api/insights/chat", json={"message": "Raport?"})
+        assert resp.status_code == 403
+
+    def test_clear_rejects_non_manager(self, waiter_client):
+        resp = waiter_client.post("/api/insights/chat/clear", json={"session_id": "x"})
+        assert resp.status_code == 403
+
+
+class TestInsightsFallback:
+    def test_chat_fallback_shape(self, manager_client):
+        """Empty DB + no AI key → deterministic fallback over zeroed report."""
+        with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+            resp = manager_client.post(
+                "/api/insights/chat",
+                json={"message": "Rezumă perioada", "start_date": "2026-05-01", "end_date": "2026-05-07"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["agent"] == "fallback"
+        assert "response_text" in data
+        assert isinstance(data["insights"], list)
+        assert data["session_id"]  # auto-generated when absent
+
+    def test_chat_preserves_session_id(self, manager_client):
+        with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+            resp = manager_client.post(
+                "/api/insights/chat",
+                json={"message": "Salut", "session_id": "fixed-session"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["session_id"] == "fixed-session"
+
+    def test_clear_session(self, manager_client):
+        resp = manager_client.post("/api/insights/chat/clear", json={"session_id": "abc"})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "cleared"
+
+    def test_chat_invalid_date_422(self, manager_client):
+        with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+            resp = manager_client.post(
+                "/api/insights/chat",
+                json={"message": "x", "start_date": "not-a-date"},
+            )
+        assert resp.status_code == 422

--- a/backend/tests/unit/api/test_menu.py
+++ b/backend/tests/unit/api/test_menu.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from models.user import User, UserRole
 from models.category import Category
 from models.menu_item import MenuItem
@@ -80,3 +80,31 @@ def test_delete_category_with_items(auth_client, mock_db_session):
     response = auth_client.delete("/api/categories/1")
     assert response.status_code == 400
     assert "Nu se poate șterge categoria" in response.json()["detail"]
+
+
+# --- AI Menu Content Generator (/menu/ai-generate) ---
+
+def test_ai_generate_requires_manager(client):
+    """No auth → 401 (Manager-only endpoint)."""
+    response = client.post("/api/menu/ai-generate", json={"name": "Pizza"})
+    assert response.status_code == 401
+
+def test_ai_generate_fallback_shape(auth_client, mock_db_session):
+    """No AI key → deterministic fallback suggestion, no DB writes."""
+    mock_db_session.exec.return_value.all.return_value = [
+        Category(id=1, name="Pizza"), Category(id=2, name="Băuturi")
+    ]
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+        response = auth_client.post(
+            "/api/menu/ai-generate",
+            json={"name": "Pizza Margherita", "ingredients": "rosii, mozzarella"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["agent"] == "fallback"
+    assert "Pizza Margherita" in data["description"]
+    assert "suggested_category" in data and "is_new" in data["suggested_category"]
+    assert "price_band" in data
+    # Non-destructiv: nu se scrie nimic în DB
+    mock_db_session.add.assert_not_called()
+    mock_db_session.commit.assert_not_called()

--- a/backend/tests/unit/api/test_recommendations.py
+++ b/backend/tests/unit/api/test_recommendations.py
@@ -44,13 +44,16 @@ class TestRecommendationsAuth:
     def test_chat_valid_guest_token(self, client_with_db):
         """Valid guest token should access recommendations with fallback (no AI configured)."""
         token = create_guest_token(table_id=1)
-        
-        response = client_with_db.post(
-            "/api/recommendations/chat",
-            json={"message": "I want something spicy"},
-            headers={"Authorization": f"Bearer {token}"}
-        )
-        
+
+        # Forțăm fallback-ul explicit ca testul să fie determinist indiferent dacă
+        # mediul local are DEEPSEEK_API_KEY setat în .env.
+        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
+            response = client_with_db.post(
+                "/api/recommendations/chat",
+                json={"message": "I want something spicy"},
+                headers={"Authorization": f"Bearer {token}"}
+            )
+
         assert response.status_code == 200
         data = response.json()
         assert "response_text" in data

--- a/backend/tests/unit/core/conftest.py
+++ b/backend/tests/unit/core/conftest.py
@@ -1,0 +1,81 @@
+"""
+Shared fixtures/helpers for the manager-side AI agent unit tests
+(deterministic, mocked — no real API calls).
+"""
+
+from typing import Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+
+MOCK_REPORT: Dict = {
+    "start_date": "2026-06-01",
+    "end_date": "2026-06-07",
+    "total_revenue": 4520.0,
+    "total_orders": 128,
+    "average_order_value": 35.31,
+    "top_items": [
+        {"name": "Margherita Pizza", "quantity_sold": 64},
+        {"name": "Classic Cheeseburger", "quantity_sold": 41},
+        {"name": "Caesar Salad", "quantity_sold": 33},
+    ],
+    "revenue_by_day": [
+        {"date": "2026-06-06", "revenue": 2100.0},
+        {"date": "2026-06-07", "revenue": 2420.0},
+    ],
+}
+
+MOCK_MENU_PRICES: List[Dict] = [
+    {"name": "Margherita Pizza", "price": 35.0, "is_available": True, "category": "Pizza"},
+    {"name": "Classic Cheeseburger", "price": 40.0, "is_available": True, "category": "Burgers"},
+    {"name": "Caesar Salad", "price": 26.0, "is_available": True, "category": "Salads"},
+    {"name": "Fresh Fruit Salad", "price": 18.0, "is_available": True, "category": "Desserts"},
+]
+
+
+@pytest.fixture
+def mock_report() -> Dict:
+    return {**MOCK_REPORT}
+
+
+@pytest.fixture
+def mock_menu_prices() -> List[Dict]:
+    return [dict(i) for i in MOCK_MENU_PRICES]
+
+
+@pytest.fixture
+def mock_categories() -> List[str]:
+    return ["Pizza", "Burgers", "Salads", "Desserts"]
+
+
+def make_mock_deepseek(content: str, capture: List[Dict] = None) -> MagicMock:
+    """
+    Mock DeepSeek client whose chat.completions.create returns `content`.
+    If `capture` is given, each call's kwargs (incl. messages) are recorded so
+    tests can assert what was actually sent in the prompt.
+    """
+    client = MagicMock()
+
+    async def _create(*args, **kwargs):
+        if capture is not None:
+            capture.append(kwargs)
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = content
+        resp.choices[0].finish_reason = "stop"
+        return resp
+
+    client.chat.completions.create = _create
+    return client
+
+
+@pytest.fixture(autouse=True)
+def reset_agent_sessions():
+    """Clear in-memory conversation history between tests."""
+    from core.ai import _chat_sessions, _insights_sessions
+    _chat_sessions.clear()
+    _insights_sessions.clear()
+    yield
+    _chat_sessions.clear()
+    _insights_sessions.clear()

--- a/backend/tests/unit/core/test_ai.py
+++ b/backend/tests/unit/core/test_ai.py
@@ -1,5 +1,13 @@
+import json
 import pytest
-from core.ai import run_ai_kds_optimizer, run_ai_safety_agent
+from unittest.mock import AsyncMock, MagicMock, patch
+from core.ai import (
+    run_ai_kds_optimizer,
+    run_ai_safety_agent,
+    run_manager_insights_agent,
+    run_menu_content_agent,
+    clear_insights_session,
+)
 
 def test_run_ai_kds_optimizer_high_complexity():
     items = [{"prep_time": 15}, {"prep_time": 15}]
@@ -20,3 +28,168 @@ def test_run_ai_safety_agent_normal():
     notes = "Vreau mai mult sos"
     result = run_ai_safety_agent(notes)
     assert result == "NORMAL"
+
+
+# ============================================================================
+# AGENT AI 3: Manager Analytics Agent
+# ============================================================================
+
+SAMPLE_REPORT = {
+    "start_date": "2026-05-01",
+    "end_date": "2026-05-07",
+    "total_revenue": 1250.5,
+    "total_orders": 40,
+    "average_order_value": 31.26,
+    "top_items": [{"name": "Burger", "quantity_sold": 25}],
+    "revenue_by_day": [{"date": "2026-05-01", "revenue": 200.0}],
+}
+
+
+def _mock_client_returning(content: str):
+    """Build an AsyncOpenAI-like mock whose completion returns `content`."""
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "stop"
+    completion = MagicMock()
+    completion.choices = [choice]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=completion)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_insights_fallback_when_no_api_key():
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+        result = await run_manager_insights_agent("Cum au fost vânzările?", "s1", SAMPLE_REPORT)
+    assert result["agent"] == "fallback"
+    assert result["session_id"] == "s1"
+    assert isinstance(result["insights"], list) and result["insights"]
+    # Rezumatul determinist trebuie să conțină cifra reală
+    assert "1250.5" in result["response_text"]
+
+
+@pytest.mark.asyncio
+async def test_insights_agent_parses_model_json():
+    payload = json.dumps({
+        "response_text": "Vânzările au crescut.",
+        "insights": ["Burger e cel mai vândut", "Venit 1250.5 RON"],
+        "follow_up_question": "Vrei detalii pe zile?",
+    })
+    mock_client = _mock_client_returning(payload)
+    clear_insights_session("s-json")
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_manager_insights_agent("De ce a crescut?", "s-json", SAMPLE_REPORT)
+    assert result["agent"] != "fallback"
+    assert result["response_text"] == "Vânzările au crescut."
+    assert result["insights"] == ["Burger e cel mai vândut", "Venit 1250.5 RON"]
+    assert result["follow_up_question"] == "Vrei detalii pe zile?"
+
+
+@pytest.mark.asyncio
+async def test_insights_agent_session_history_accumulates():
+    mock_client = _mock_client_returning(json.dumps({"response_text": "ok", "insights": []}))
+    clear_insights_session("s-hist")
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        await run_manager_insights_agent("Q1", "s-hist", SAMPLE_REPORT)
+        await run_manager_insights_agent("Q2", "s-hist", SAMPLE_REPORT)
+    from core.ai import _insights_sessions
+    # 2 mesaje user + 2 assistant
+    assert len(_insights_sessions["s-hist"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_insights_agent_falls_back_on_unparseable_response():
+    mock_client = _mock_client_returning("not json at all, just prose")
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_manager_insights_agent("Q", "s-bad", SAMPLE_REPORT)
+    # _extract_json cade pe textul de recomandare meniu → tratat ca eșec → fallback insights
+    assert result["agent"] == "fallback"
+
+
+# ============================================================================
+# AGENT AI 4: Menu Content Generator
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_menu_content_fallback_when_no_api_key():
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", None):
+        result = await run_menu_content_agent("Pizza Margherita", "rosii, mozzarella", ["Pizza"])
+    assert result["agent"] == "fallback"
+    assert "Pizza Margherita" in result["description"]
+    # categoria sugerată e una existentă → nu e nouă
+    assert result["suggested_category"]["is_new"] is False
+
+
+@pytest.mark.asyncio
+async def test_menu_content_recomputes_is_new_for_existing_category():
+    # Modelul pretinde is_new=True pentru o categorie care de fapt EXISTĂ.
+    payload = json.dumps({
+        "description": "Pizza clasică italiană.",
+        "dietary_tags": "vegetarian",
+        "suggested_category": {"name": "pizza", "is_new": True},
+        "price_band": {"min": 25, "max": 40},
+        "prep_time_minutes": 15,
+    })
+    mock_client = _mock_client_returning(payload)
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_menu_content_agent("Pizza Margherita", "rosii", ["Pizza", "Băuturi"])
+    # Server recalculează: "pizza" se potrivește cu "Pizza" existentă → is_new False, nume normalizat
+    assert result["suggested_category"]["is_new"] is False
+    assert result["suggested_category"]["name"] == "Pizza"
+    assert result["dietary_tags"] == "vegetarian"
+    assert result["price_band"] == {"min": 25.0, "max": 40.0}
+    assert result["prep_time_minutes"] == 15
+
+
+@pytest.mark.asyncio
+async def test_menu_content_tolerates_malformed_field_types():
+    # Modelul întoarce suggested_category ca string și price_band ca listă —
+    # tipuri greșite. Agentul nu trebuie să arunce descrierea bună la gunoi.
+    payload = json.dumps({
+        "description": "Salată proaspătă.",
+        "dietary_tags": "vegan",
+        "suggested_category": "Salate",   # string în loc de obiect
+        "price_band": [10, 20],            # listă în loc de obiect
+        "prep_time_minutes": "abc",        # ne-numeric
+    })
+    mock_client = _mock_client_returning(payload)
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_menu_content_agent("Salată Caesar", "salată", ["Pizza"])
+    # Păstrează descrierea (nu cade pe fallback), normalizează tipurile greșite.
+    assert result["agent"] != "fallback"
+    assert result["description"] == "Salată proaspătă."
+    assert result["dietary_tags"] == "vegan"
+    assert result["suggested_category"] == {"name": "Salate", "is_new": True}
+    assert result["price_band"] == {"min": 0.0, "max": 0.0}
+    assert result["prep_time_minutes"] is None
+
+
+@pytest.mark.asyncio
+async def test_menu_content_flags_genuinely_new_category():
+    payload = json.dumps({
+        "description": "Desert cremos.",
+        "dietary_tags": "",
+        "suggested_category": {"name": "Deserturi", "is_new": False},
+        "price_band": {"min": 10, "max": 20},
+        "prep_time_minutes": None,
+    })
+    mock_client = _mock_client_returning(payload)
+    with patch("core.ai.settings.DEEPSEEK_API_KEY", "fake-key"), \
+         patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.get_deepseek_client", return_value=mock_client):
+        result = await run_menu_content_agent("Tiramisu", "mascarpone", ["Pizza"])
+    # "Deserturi" nu există în listă → is_new True, indiferent ce a zis modelul
+    assert result["suggested_category"]["is_new"] is True
+    assert result["suggested_category"]["name"] == "Deserturi"

--- a/backend/tests/unit/core/test_insights_agent.py
+++ b/backend/tests/unit/core/test_insights_agent.py
@@ -1,0 +1,144 @@
+"""
+Manager Insights Agent — deterministic regression tests (mocked, no API calls).
+
+These pin the agent's *plumbing* around the model: prompt assembly (menu prices
+reach the prompt), JSON parsing resilience, multi-turn history, fallback, and the
+response-shape contract. Quality of the live model is measured separately by the
+opt-in evals in tests/evals/test_insights_quality.py.
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from core.ai import run_manager_insights_agent, _format_report_for_prompt
+from tests.unit.core.conftest import make_mock_deepseek
+from tests.evals.metrics import grounding_score, report_numbers, is_discount_of
+
+pytestmark = pytest.mark.unit
+
+
+@contextmanager
+def mocked_ai(content: str, capture=None):
+    """Force the AI path on and route it through a mock DeepSeek client."""
+    with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.settings.DEEPSEEK_API_KEY", "test-key"), \
+         patch("core.ai.settings.DEEPSEEK_MODEL", "deepseek-test"), \
+         patch("core.ai.get_deepseek_client", return_value=make_mock_deepseek(content, capture)):
+        yield
+
+
+class TestInsightsGrounding:
+    @pytest.mark.asyncio
+    async def test_fallback_numbers_are_grounded(self, mock_report):
+        """Fallback summary cites only figures present in the report."""
+        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
+            result = await run_manager_insights_agent(
+                message="Cum au fost vânzările?",
+                session_id="ins-fallback-001",
+                report_data=mock_report,
+            )
+
+        assert result["agent"] == "fallback"
+        allowed = report_numbers(mock_report)
+        text = result["response_text"] + " " + " ".join(result["insights"])
+        assert grounding_score(text, allowed) >= 0.99
+
+
+class TestInsightsPricing:
+    """Regression for the original bug: the agent had no prices to reason about."""
+
+    @pytest.mark.asyncio
+    async def test_menu_prices_reach_the_prompt(self, mock_report, mock_menu_prices):
+        capture = []
+        content = json.dumps({"response_text": "ok", "insights": [], "follow_up_question": None})
+        with mocked_ai(content, capture=capture):
+            await run_manager_insights_agent(
+                message="Ce preț de happy hour la Margherita Pizza?",
+                session_id="ins-price-001",
+                report_data=mock_report,
+                menu_items=mock_menu_prices,
+            )
+
+        system_prompt = capture[0]["messages"][0]["content"]
+        for item in mock_menu_prices:
+            assert item["name"] in system_prompt
+            assert str(item["price"]) in system_prompt
+
+    @pytest.mark.asyncio
+    async def test_happy_hour_price_is_discount_of_real_price(self, mock_report, mock_menu_prices):
+        pizza = next(i for i in mock_menu_prices if i["name"] == "Margherita Pizza")
+        base = pizza["price"]
+        suggested = round(base * 0.8, 2)
+        content = json.dumps({
+            "response_text": f"Happy hour la Margherita Pizza: {suggested} RON (−20% de la {base}).",
+            "insights": [],
+            "follow_up_question": None,
+        })
+        with mocked_ai(content):
+            result = await run_manager_insights_agent(
+                message="preț happy hour Margherita Pizza",
+                session_id="ins-price-002",
+                report_data=mock_report,
+                menu_items=mock_menu_prices,
+            )
+
+        assert is_discount_of(suggested, base)
+        assert str(suggested) in result["response_text"]
+
+
+class TestInsightsRobustness:
+    @pytest.mark.asyncio
+    async def test_prose_wrapped_json_is_parsed(self, mock_report):
+        content = (
+            "Sigur, iată analiza:\n```json\n"
+            + json.dumps({"response_text": "Venit bun.", "insights": ["ok"], "follow_up_question": None})
+            + "\n```\nSper că ajută!"
+        )
+        with mocked_ai(content):
+            result = await run_manager_insights_agent(
+                message="analiză", session_id="ins-robust-001", report_data=mock_report
+            )
+        assert result["agent"] != "fallback"
+        assert result["response_text"] == "Venit bun."
+
+    @pytest.mark.asyncio
+    async def test_unparseable_output_falls_back(self, mock_report):
+        with mocked_ai("îmi pare rău, nu am înțeles"):
+            result = await run_manager_insights_agent(
+                message="analiză", session_id="ins-robust-002", report_data=mock_report
+            )
+        assert result["agent"] == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_history_retained(self, mock_report):
+        capture = []
+        content = json.dumps({"response_text": "răspuns", "insights": [], "follow_up_question": None})
+        with mocked_ai(content, capture=capture):
+            sid = "ins-history-001"
+            await run_manager_insights_agent("prima întrebare", sid, mock_report)
+            await run_manager_insights_agent("a doua întrebare", sid, mock_report)
+
+        contents = [m["content"] for m in capture[1]["messages"]]
+        assert "prima întrebare" in contents
+        assert "răspuns" in contents
+
+
+class TestInsightsStructure:
+    @pytest.mark.asyncio
+    async def test_response_fields_present(self, mock_report):
+        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
+            result = await run_manager_insights_agent(
+                message="rezumat", session_id="ins-struct-001", report_data=mock_report
+            )
+        for field in ("response_text", "insights", "follow_up_question", "session_id", "agent"):
+            assert field in result
+        assert isinstance(result["insights"], list)
+
+    def test_report_formatter_includes_key_figures(self, mock_report):
+        text = _format_report_for_prompt(mock_report)
+        assert "4520.0" in text
+        assert "128" in text
+        assert "Margherita Pizza" in text

--- a/backend/tests/unit/core/test_menu_content_agent.py
+++ b/backend/tests/unit/core/test_menu_content_agent.py
@@ -1,0 +1,167 @@
+"""
+Menu Content Generator Agent — deterministic regression tests (mocked, no API).
+
+Focus is the server-side validation in _finalize, the trust boundary:
+- is_new recomputed against the REAL category list (model flag ignored)
+- field length-clamping / type-coercion
+- malformed model output tolerated
+- fallback template when AI is disabled
+
+Live-model quality is measured by the opt-in evals in
+tests/evals/test_menu_content_quality.py.
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from core.ai import run_menu_content_agent
+from tests.unit.core.conftest import make_mock_deepseek
+
+pytestmark = pytest.mark.unit
+
+
+@contextmanager
+def mocked_ai(content: str, capture=None):
+    with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", True), \
+         patch("core.ai.settings.DEEPSEEK_API_KEY", "test-key"), \
+         patch("core.ai.settings.DEEPSEEK_MODEL", "deepseek-test"), \
+         patch("core.ai.get_deepseek_client", return_value=make_mock_deepseek(content, capture)):
+        yield
+
+
+class TestCategoryValidation:
+    @pytest.mark.asyncio
+    async def test_existing_category_forces_is_new_false(self, mock_categories):
+        content = json.dumps({
+            "description": "Pizza picantă cu salam.",
+            "dietary_tags": "",
+            "suggested_category": {"name": "pizza", "is_new": True},
+            "price_band": {"min": 30.0, "max": 40.0},
+            "prep_time_minutes": 15,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(
+                name="Pizza Diavola", ingredients="salam, ardei iute",
+                existing_categories=mock_categories,
+            )
+        assert result["suggested_category"]["is_new"] is False
+        assert result["suggested_category"]["name"] == "Pizza"
+
+    @pytest.mark.asyncio
+    async def test_new_category_forces_is_new_true(self, mock_categories):
+        content = json.dumps({
+            "description": "Tapas spaniole de partajat.",
+            "dietary_tags": "vegetarian",
+            "suggested_category": {"name": "Tapas", "is_new": False},
+            "price_band": {"min": 20.0, "max": 28.0},
+            "prep_time_minutes": 12,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(
+                name="Patatas Bravas", ingredients="cartofi, sos picant",
+                existing_categories=mock_categories,
+            )
+        assert result["suggested_category"]["is_new"] is True
+        assert result["suggested_category"]["name"] == "Tapas"
+
+    @pytest.mark.asyncio
+    async def test_category_as_plain_string_tolerated(self, mock_categories):
+        content = json.dumps({
+            "description": "Desert cu ciocolată.",
+            "dietary_tags": "vegetarian",
+            "suggested_category": "Desserts",
+            "price_band": {"min": 18.0, "max": 24.0},
+            "prep_time_minutes": 10,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(
+                name="Lava Cake", existing_categories=mock_categories,
+            )
+        assert result["suggested_category"]["name"] == "Desserts"
+        assert result["suggested_category"]["is_new"] is False
+
+
+class TestFieldSanitization:
+    @pytest.mark.asyncio
+    async def test_long_fields_are_truncated(self, mock_categories):
+        content = json.dumps({
+            "description": "x" * 900,
+            "dietary_tags": "y" * 400,
+            "suggested_category": {"name": "Pizza", "is_new": False},
+            "price_band": {"min": 30.0, "max": 40.0},
+            "prep_time_minutes": 15,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
+        assert len(result["description"]) <= 500
+        assert len(result["dietary_tags"]) <= 255
+
+    @pytest.mark.asyncio
+    async def test_price_band_coerced_and_rounded(self, mock_categories):
+        content = json.dumps({
+            "description": "ok",
+            "dietary_tags": "",
+            "suggested_category": {"name": "Pizza", "is_new": False},
+            "price_band": {"min": "29.999", "max": "41.234"},
+            "prep_time_minutes": 15,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
+        assert result["price_band"]["min"] == 30.0
+        assert result["price_band"]["max"] == 41.23
+
+    @pytest.mark.asyncio
+    async def test_missing_or_invalid_price_band_defaults(self, mock_categories):
+        content = json.dumps({
+            "description": "ok",
+            "dietary_tags": "",
+            "suggested_category": {"name": "Pizza", "is_new": False},
+            "price_band": "necunoscut",
+            "prep_time_minutes": "nu știu",
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
+        assert result["price_band"] == {"min": 0.0, "max": 0.0}
+        assert result["prep_time_minutes"] is None
+
+
+class TestFallback:
+    @pytest.mark.asyncio
+    async def test_fallback_when_ai_disabled(self, mock_categories):
+        with patch("core.ai.settings.USE_AI_RECOMMENDATIONS", False):
+            result = await run_menu_content_agent(
+                name="Bruschette", ingredients="roșii, busuioc",
+                existing_categories=mock_categories,
+            )
+        assert result["agent"] == "fallback"
+        assert "Bruschette" in result["description"]
+
+    @pytest.mark.asyncio
+    async def test_empty_description_falls_back(self, mock_categories):
+        content = json.dumps({"description": "", "suggested_category": {"name": "Pizza"}})
+        with mocked_ai(content):
+            result = await run_menu_content_agent(
+                name="Mystery", ingredients="x", existing_categories=mock_categories,
+            )
+        assert result["agent"] == "fallback"
+
+
+class TestStructure:
+    @pytest.mark.asyncio
+    async def test_response_fields_present(self, mock_categories):
+        content = json.dumps({
+            "description": "ok",
+            "dietary_tags": "vegetarian",
+            "suggested_category": {"name": "Pizza", "is_new": False},
+            "price_band": {"min": 30.0, "max": 40.0},
+            "prep_time_minutes": 15,
+        })
+        with mocked_ai(content):
+            result = await run_menu_content_agent(name="Test", existing_categories=mock_categories)
+        for field in ("description", "dietary_tags", "suggested_category", "price_band", "prep_time_minutes", "agent"):
+            assert field in result
+        assert set(result["suggested_category"].keys()) == {"name", "is_new"}
+        assert set(result["price_band"].keys()) == {"min", "max"}

--- a/frontend/__tests__/app/manager/ClientPage.test.tsx
+++ b/frontend/__tests__/app/manager/ClientPage.test.tsx
@@ -93,6 +93,48 @@ describe('Manager Dashboard', () => {
     expect(screen.getByRole('button', { name: 'Adaugă Produs' })).toBeInTheDocument()
   })
 
+  it('fills the product form from the AI content generator', async () => {
+    const ok = (data: unknown) =>
+      ({ ok: true, json: () => Promise.resolve(data) }) as unknown as Response
+    vi.mocked(api.apiRequest).mockImplementation((url: string) => {
+      if (url === '/menu') {
+        return Promise.resolve(ok([{ id: 1, name: 'Burger', price: 20, category: 'Food', is_available: true }]))
+      }
+      if (url === '/categories') {
+        return Promise.resolve(ok([{ id: 1, name: 'Food' }]))
+      }
+      if (url === '/manager/stats') {
+        return Promise.resolve(ok({ total_revenue: 0, total_orders: 0, menu_items_count: 1 }))
+      }
+      if (url === '/menu/ai-generate') {
+        return Promise.resolve(ok({
+          description: 'Un burger suculent cu vită Wagyu.',
+          dietary_tags: 'conține gluten',
+          suggested_category: { name: 'Food', is_new: false },
+          price_band: { min: 30, max: 45 },
+          prep_time_minutes: 12,
+          agent: 'deepseek-v4-flash',
+        }))
+      }
+      return Promise.resolve(ok({}))
+    })
+
+    render(<ManagerPage />)
+    await waitFor(() => expect(screen.getByText('Burger')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('+ Adaugă Produs Nou'))
+    // Numele e necesar pentru a activa butonul AI.
+    fireEvent.change(screen.getByPlaceholderText('Ex: Burger Wagyu'), { target: { value: 'Burger Wagyu' } })
+    fireEvent.click(screen.getByRole('button', { name: /Generează cu AI/i }))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Un burger suculent cu vită Wagyu.')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('conține gluten')).toBeInTheDocument()
+    })
+    // Intervalul de preț sugerat e afișat ca hint.
+    expect(screen.getByText(/Interval de preț sugerat/i)).toBeInTheDocument()
+  })
+
   it('can switch tabs', async () => {
     render(<ManagerPage />)
     

--- a/frontend/__tests__/components/AIChatWidget.test.tsx
+++ b/frontend/__tests__/components/AIChatWidget.test.tsx
@@ -1,14 +1,15 @@
-"""
-Tests for AIChatWidget component.
-Covers: messages render, loading state, add-to-cart callback, and API mocking.
-"""
+/**
+ * Tests for AIChatWidget component.
+ * Covers: messages render, loading state, add-to-cart callback, and API mocking.
+ */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { AIChatWidget } from "@/components/AIChatWidget";
 
-// Mock fetch globally
-global.fetch = vi.fn();
+// Mock fetch globally (typed reference avoids `as any` at each call site)
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
 
 describe("AIChatWidget", () => {
   const mockOnAddToCart = vi.fn();
@@ -18,7 +19,7 @@ describe("AIChatWidget", () => {
     Storage.prototype.getItem = vi.fn(() => "mock-token");
     
     // Mock successful API response
-    (fetch as any).mockResolvedValue({
+    mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
         response_text: "Here are some dishes you might like!",
@@ -67,7 +68,7 @@ describe("AIChatWidget", () => {
 
   it("shows loading state while waiting for API response", async () => {
     // Delay the fetch response
-    (fetch as any).mockImplementation(() => 
+    mockFetch.mockImplementation(() => 
       new Promise((resolve) => setTimeout(resolve, 100))
     );
     
@@ -188,7 +189,7 @@ describe("AIChatWidget", () => {
     
     // Wait for second API call with session_id
     await waitFor(() => {
-      const calls = (fetch as any).mock.calls;
+      const calls = mockFetch.mock.calls;
       const lastCall = calls[calls.length - 1];
       const body = JSON.parse(lastCall[1].body);
       
@@ -206,10 +207,9 @@ describe("AIChatWidget", () => {
       expect(screen.getByText("AI Food Assistant")).toBeInTheDocument();
     });
     
-    // Click X button
-    const closeButton = screen.getByRole("button", { name: "" }); // X icon button
-    fireEvent.click(closeButton);
-    
+    // Click X button (labeled for accessibility)
+    fireEvent.click(screen.getByRole("button", { name: /close chat/i }));
+
     // Should show launch button again
     await waitFor(() => {
       expect(screen.getByText("Let AI recommend me something")).toBeInTheDocument();
@@ -218,7 +218,7 @@ describe("AIChatWidget", () => {
 
   it("handles API error gracefully", async () => {
     // Mock failed API response
-    (fetch as any).mockRejectedValue(new Error("Network error"));
+    mockFetch.mockRejectedValue(new Error("Network error"));
     
     render(<AIChatWidget onAddToCart={mockOnAddToCart} />);
     
@@ -233,32 +233,32 @@ describe("AIChatWidget", () => {
 
   it("does not send message when input is empty", async () => {
     render(<AIChatWidget onAddToCart={mockOnAddToCart} />);
-    
-    // Open chat
+
+    // Open chat — this auto-sends a greeting, so wait for that round-trip first
     fireEvent.click(screen.getByText("Let AI recommend me something"));
-    
+
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/Tell me what you're craving/i)).toBeInTheDocument();
+      expect(screen.getByText("Here are some dishes you might like!")).toBeInTheDocument();
     });
-    
-    // Try to send empty message
+
+    // Reset the fetch counter, then press Enter on an empty input
+    mockFetch.mockClear();
     const input = screen.getByPlaceholderText(/Tell me what you're craving/i);
     fireEvent.keyDown(input, { key: "Enter" });
-    
-    // Should not call fetch
+
+    // Empty input must not trigger another request
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("does not open chat when no token is available", () => {
+  it("does not call the recommendation API when no token is available", () => {
     // Mock no token
     Storage.prototype.getItem = vi.fn(() => null);
-    
+
     render(<AIChatWidget onAddToCart={mockOnAddToCart} />);
-    
-    // Try to open chat
+
+    // Opening the chat is allowed, but without a token nothing is sent
     fireEvent.click(screen.getByText("Let AI recommend me something"));
-    
-    // Should not show chat content
-    expect(screen.queryByText("AI Food Assistant")).not.toBeInTheDocument();
+
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/__tests__/components/ManagerInsightsChat.test.tsx
+++ b/frontend/__tests__/components/ManagerInsightsChat.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ManagerInsightsChat } from '@/components/ManagerInsightsChat'
+import * as api from '@/lib/api'
+
+vi.mock('@/lib/api', () => ({ apiRequest: vi.fn() }))
+
+// Răspuns minimal compatibil cu Response, fără a folosi `any`.
+const okResponse = (data: unknown) =>
+  ({ ok: true, json: () => Promise.resolve(data) }) as unknown as Response
+
+describe('ManagerInsightsChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.apiRequest).mockResolvedValue(
+      okResponse({
+        response_text: 'Vânzările au fost bune.',
+        insights: ['Top produs: Burger'],
+        follow_up_question: null,
+        session_id: 'sess-1',
+        agent: 'fallback',
+      }),
+    )
+  })
+
+  it('shows the empty-state prompt and suggestion chips', () => {
+    render(<ManagerInsightsChat startDate="2026-05-01" endDate="2026-05-07" />)
+    expect(screen.getByText(/Întreabă-mă orice/i)).toBeInTheDocument()
+    expect(screen.getByText('Care e cel mai vândut produs?')).toBeInTheDocument()
+  })
+
+  it('sends a question and renders the AI response with insights', async () => {
+    render(<ManagerInsightsChat startDate="2026-05-01" endDate="2026-05-07" />)
+
+    const field = screen.getByPlaceholderText(/Scrie o întrebare/i)
+    fireEvent.change(field, { target: { value: 'Cum a fost luna?' } })
+    fireEvent.submit(field.closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByText('Vânzările au fost bune.')).toBeInTheDocument()
+      expect(screen.getByText('Top produs: Burger')).toBeInTheDocument()
+    })
+
+    // Trimite mesajul + perioada selectată către backend.
+    expect(api.apiRequest).toHaveBeenCalledWith(
+      '/insights/chat',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"start_date":"2026-05-01"'),
+      }),
+    )
+  })
+
+  it('sends a suggestion chip when clicked', async () => {
+    render(<ManagerInsightsChat startDate="2026-05-01" endDate="2026-05-07" />)
+    fireEvent.click(screen.getByText('Care e cel mai vândut produs?'))
+    await waitFor(() => {
+      expect(screen.getByText('Vânzările au fost bune.')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/app/manager/ClientPage.tsx
+++ b/frontend/app/manager/ClientPage.tsx
@@ -7,7 +7,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import UserProfileMenu from "@/components/ui/UserProfileMenu";
 import ClientRoleGuard from "@/components/ClientRoleGuard";
 import { apiRequest } from "@/lib/api";
-import { Pencil, Trash2 } from "lucide-react";
+import { ManagerInsightsChat } from "@/components/ManagerInsightsChat";
+import { Pencil, Trash2, Sparkles } from "lucide-react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
@@ -70,6 +71,11 @@ export default function ManagerPage() {
   const [formPrepTime, setFormPrepTime] = useState("");
   const [formDietary, setFormDietary] = useState("");
   const [isFormAvailable, setIsFormAvailable] = useState(true);
+
+  // AI menu content generator (non-destructiv: doar populează formularul)
+  const [aiGenerating, setAiGenerating] = useState(false);
+  const [aiNewCategory, setAiNewCategory] = useState<string | null>(null);
+  const [aiPriceBand, setAiPriceBand] = useState<{ min: number; max: number } | null>(null);
 
   const [previewImage, setPreviewImage] = useState<string | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
@@ -140,6 +146,8 @@ export default function ManagerPage() {
     setPreviewImage(null);
     setImageUrl(null);
     setCompressionStats(null);
+    setAiNewCategory(null);
+    setAiPriceBand(null);
   }
 
   function handleAddNew() {
@@ -161,7 +169,58 @@ export default function ManagerPage() {
     setIsFormAvailable(item.is_available);
     setPreviewImage(item.image_url);
     setImageUrl(item.image_url);
+    setAiNewCategory(null);
+    setAiPriceBand(null);
     setIsModalOpen(true);
+  }
+
+  async function handleAiGenerate() {
+    if (formName.trim().length < 2) {
+      showToast("Introdu un nume de produs (minim 2 caractere)", "error");
+      return;
+    }
+    setAiGenerating(true);
+    setAiNewCategory(null);
+    try {
+      // price_hint trebuie să fie > 0 (backend respinge 0); altfel îl omitem.
+      const priceHint = formPrice ? parseFloat(formPrice) : NaN;
+      const res = await apiRequest("/menu/ai-generate", {
+        method: "POST",
+        body: JSON.stringify({
+          name: formName.trim(),
+          ingredients: formIngredients.trim() || null,
+          price_hint: priceHint > 0 ? priceHint : null,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(typeof err.detail === "string" ? err.detail : "Generare eșuată");
+      }
+      const data = await res.json();
+      if (data.description) setFormDescription(data.description);
+      if (data.dietary_tags) setFormDietary(data.dietary_tags);
+      if (data.prep_time_minutes != null) setFormPrepTime(String(data.prep_time_minutes));
+      if (data.price_band) setAiPriceBand(data.price_band);
+      const cat = data.suggested_category;
+      if (cat) {
+        if (cat.is_new) {
+          // Categorie nouă: nu o creăm automat — îi spunem managerului s-o adauge.
+          setAiNewCategory(cat.name);
+        } else {
+          const match = categories.find((c) => c.name.toLowerCase() === cat.name.toLowerCase());
+          if (match) setFormCategoryId(match.id.toString());
+        }
+      }
+      showToast(
+        data.agent === "fallback"
+          ? "Sugestie generată (AI indisponibil — text de bază)"
+          : "Conținut generat cu AI"
+      );
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : "Eroare la generare", "error");
+    } finally {
+      setAiGenerating(false);
+    }
   }
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -462,12 +521,18 @@ export default function ManagerPage() {
           <DialogContent className="bg-slate-900 border-slate-700 text-white sm:max-w-[550px] max-h-[90vh] overflow-y-auto">
             <DialogHeader><DialogTitle className="text-2xl font-bold text-green-400">{editingItem ? "Editează Produs" : "Adaugă Produs Nou"}</DialogTitle></DialogHeader>
             <div className="grid gap-4 py-2">
+              <div className="flex items-center justify-between bg-slate-800/50 border border-slate-700 rounded-lg px-3 py-2">
+                <span className="text-xs text-slate-400">Completează automat descrierea, tag-urile și categoria cu AI</span>
+                <Button type="button" size="sm" onClick={handleAiGenerate} disabled={aiGenerating || formName.trim().length < 2} className="bg-purple-600 hover:bg-purple-500 font-semibold shrink-0"><Sparkles size={14} className="mr-1.5" />{aiGenerating ? "Se generează..." : "Generează cu AI"}</Button>
+              </div>
               <div><label className="text-sm text-slate-400 mb-1.5 block">Nume Produs *</label><input type="text" value={formName} onChange={(e) => setFormName(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-green-500 outline-none transition-colors" placeholder="Ex: Burger Wagyu" /></div>
               <div><label className="text-sm text-slate-400 mb-1.5 block">Descriere</label><textarea value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-green-500 outline-none transition-colors min-h-[80px] resize-y" placeholder="Descrierea produsului..." /></div>
               <div className="grid grid-cols-2 gap-4">
                 <div><label className="text-sm text-slate-400 mb-1.5 block">Preț (RON) *</label><input type="number" step="0.01" min="0.01" value={formPrice} onChange={(e) => setFormPrice(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-green-500 outline-none transition-colors" placeholder="0.00" /></div>
                 <div><label className="text-sm text-slate-400 mb-1.5 block">Categorie *</label><select value={formCategoryId} onChange={(e) => setFormCategoryId(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white focus:border-green-500 outline-none transition-colors"><option value="">Selectează...</option>{categories.map((cat) => (<option key={cat.id} value={cat.id}>{cat.name}</option>))}</select></div>
               </div>
+              {aiPriceBand && (aiPriceBand.min > 0 || aiPriceBand.max > 0) && <p className="text-xs text-purple-300">💡 Interval de preț sugerat de AI: {aiPriceBand.min}–{aiPriceBand.max} RON</p>}
+              {aiNewCategory && <p className="text-xs text-purple-300">💡 AI sugerează o categorie nouă: <b>{aiNewCategory}</b> — creează-o din tab-ul „Categorii”, apoi selecteaz-o aici.</p>}
               <div><label className="text-sm text-slate-400 mb-1.5 block">Imagine Produs</label><div className="flex gap-3 items-start"><div className="flex-1"><input type="file" ref={fileInputRef} accept="image/jpeg,image/png,image/webp,image/gif" onChange={handleFileChange} className="w-full text-sm text-slate-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-slate-800 file:text-green-400 file:font-medium hover:file:bg-slate-700 file:cursor-pointer file:transition-colors" />{uploadingImage && <p className="text-xs text-yellow-400 mt-1.5">Se încarcă și se optimizează imaginea...</p>}{compressionStats && <p className="text-xs text-green-400 mt-1.5">✓ Optimizat: {(compressionStats.original / 1024).toFixed(1)}KB → {(compressionStats.optimized / 1024).toFixed(1)}KB</p>}</div>{previewImage && <img src={previewImage} alt="Preview" className="w-16 h-16 rounded-lg object-cover border border-slate-700 shrink-0" />}</div></div>
               <div><label className="text-sm text-slate-400 mb-1.5 block">Ingrediente</label><input type="text" value={formIngredients} onChange={(e) => setFormIngredients(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-green-500 outline-none transition-colors" placeholder="Ex: carne vită, cheddar, ceapă" /></div>
               <div className="grid grid-cols-2 gap-4">
@@ -622,6 +687,7 @@ export default function ManagerPage() {
           )}
           </>
         )}
+        <ManagerInsightsChat key={`${reportStart}_${reportEnd}`} startDate={reportStart} endDate={reportEnd} />
         </>
         )}
 

--- a/frontend/components/AIChatWidget.tsx
+++ b/frontend/components/AIChatWidget.tsx
@@ -111,7 +111,7 @@ export function AIChatWidget({ onAddToCart }: AIChatWidgetProps) {
           <Sparkles className="mr-2 h-4 w-4 text-yellow-400" />
           AI Food Assistant
         </CardTitle>
-        <Button variant="ghost" size="sm" onClick={() => setIsOpen(false)} className="text-slate-400 hover:text-white hover:bg-slate-800">
+        <Button variant="ghost" size="sm" aria-label="Close chat" onClick={() => setIsOpen(false)} className="text-slate-400 hover:text-white hover:bg-slate-800">
           <X className="h-4 w-4" />
         </Button>
       </CardHeader>

--- a/frontend/components/ManagerInsightsChat.tsx
+++ b/frontend/components/ManagerInsightsChat.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Sparkles, Send } from "lucide-react";
+import { apiRequest } from "@/lib/api";
+
+interface InsightMessage {
+  role: "user" | "ai";
+  content: string;
+  insights?: string[];
+}
+
+interface ManagerInsightsChatProps {
+  startDate: string;
+  endDate: string;
+}
+
+const SUGGESTIONS = [
+  "Cum au fost vânzările în această perioadă?",
+  "Care e cel mai vândut produs?",
+  "Ce ar trebui să promovez?",
+];
+
+export function ManagerInsightsChat({ startDate, endDate }: ManagerInsightsChatProps) {
+  const [messages, setMessages] = useState<InsightMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Notă: când se schimbă perioada (startDate/endDate), părintele remontează
+  // componenta printr-un `key` nou, deci starea (sesiune + mesaje) se resetează
+  // singură — context curat de raport, fără efect care apelează setState.
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, isLoading]);
+
+  const sendMessage = async (msg: string) => {
+    if (!msg.trim() || isLoading) return;
+    setInput("");
+    setIsLoading(true);
+    setMessages((prev) => [...prev, { role: "user", content: msg }]);
+
+    try {
+      const res = await apiRequest("/insights/chat", {
+        method: "POST",
+        body: JSON.stringify({
+          message: msg,
+          session_id: sessionId,
+          start_date: startDate,
+          end_date: endDate,
+        }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setSessionId(data.session_id);
+      setMessages((prev) => [
+        ...prev,
+        { role: "ai", content: data.response_text, insights: data.insights },
+      ]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { role: "ai", content: "Nu am putut obține un răspuns. Încearcă din nou." },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card className="bg-slate-900 border-slate-800 mt-10">
+      <CardHeader>
+        <CardTitle className="text-slate-400 text-sm uppercase flex items-center gap-2">
+          <Sparkles size={16} className="text-green-400" /> Asistent AI Analiză
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div ref={scrollRef} className="max-h-80 overflow-y-auto space-y-3 mb-4">
+          {messages.length === 0 && (
+            <p className="text-slate-500 text-sm">
+              Întreabă-mă orice despre datele de vânzări din perioada selectată.
+            </p>
+          )}
+          {messages.map((m, i) => (
+            <div key={i} className={m.role === "user" ? "text-right" : "text-left"}>
+              <div
+                className={`inline-block px-3 py-2 rounded-lg text-sm max-w-[90%] ${
+                  m.role === "user" ? "bg-green-600 text-white" : "bg-slate-800 text-slate-100"
+                }`}
+              >
+                <p className="whitespace-pre-wrap">{m.content}</p>
+                {m.insights && m.insights.length > 0 && (
+                  <ul className="mt-2 list-disc list-inside text-slate-300 text-xs space-y-0.5">
+                    {m.insights.map((ins, j) => (
+                      <li key={j}>{ins}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          ))}
+          {isLoading && <p className="text-slate-500 text-sm">Se analizează...</p>}
+        </div>
+
+        {messages.length === 0 && (
+          <div className="flex flex-wrap gap-2 mb-3">
+            {SUGGESTIONS.map((s) => (
+              <button
+                key={s}
+                onClick={() => sendMessage(s)}
+                className="px-3 py-1 rounded-full text-xs bg-slate-800 text-slate-300 hover:bg-slate-700"
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            sendMessage(input);
+          }}
+          className="flex gap-2"
+        >
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Scrie o întrebare despre vânzări..."
+            className="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-white placeholder-slate-500 focus:border-green-500 outline-none text-sm"
+          />
+          <Button type="submit" disabled={isLoading} className="bg-green-600 hover:bg-green-500">
+            <Send size={16} />
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
This pull request introduces new AI-powered endpoints for manager insights and menu content generation, expands the evaluation framework, and improves robustness and clarity across the backend. The changes add two new manager-facing AI endpoints: one for interactive insights chat based on real sales data, and one for suggesting new menu item content. The evaluation framework is updated to cover all three LLM agents, with detailed documentation and clear separation between real evals and regression tests. Additionally, the recommendation agent's JSON parsing is made more robust, and the sales report logic is refactored for reuse.

**New AI Endpoints for Managers:**

* Added `backend/api/insights.py` with `/insights/chat` and `/insights/chat/clear` endpoints for manager-focused AI insights, including session management, grounding in real sales and menu data, and role-based access control.
* Added `/menu/ai-generate` endpoint to suggest content for new menu items (description, dietary tags, category, price band) using the menu content agent, with non-destructive workflow and manager-only access. [[1]](diffhunk://#diff-ecf9643cbed7a4dcd9547904713eda332e4afc32884b517dd60853f674ac380bR59-R83) [[2]](diffhunk://#diff-ecf9643cbed7a4dcd9547904713eda332e4afc32884b517dd60853f674ac380bR181-R202)

**Evaluation Framework Expansion:**

* Expanded the evaluation framework in `README.md` to cover all three agents (customer recommendation, manager insights, menu generator), added metrics for grounding/faithfulness, and documented real vs. regression test distinction.

**API and Routing Improvements:**

* Registered the new insights router in the main API router, making the endpoints available under `/insights`. [[1]](diffhunk://#diff-01bac7dda477a33d45ffb0cbfa711577c2d53c1f48a1262223961ef79bd9c858R10) [[2]](diffhunk://#diff-01bac7dda477a33d45ffb0cbfa711577c2d53c1f48a1262223961ef79bd9c858R23)

**Sales Report Refactoring:**

* Refactored the sales report logic into a reusable `build_range_report` function, now used by both the `/reports/range` endpoint and the insights agent, ensuring a single source of truth for report data. [[1]](diffhunk://#diff-02f358c3180ef1a92eead123ca4dd215d997f9e866d3a2ef5ec12925f9ecd10aL46-R60) [[2]](diffhunk://#diff-02f358c3180ef1a92eead123ca4dd215d997f9e866d3a2ef5ec12925f9ecd10aR115-R125)

**Recommendation Agent Robustness:**

* Improved the recommendation agent's handling of model output by increasing the token limit, enforcing JSON output, and using a more robust JSON extraction method to prevent parsing failures and unsafe fallbacks. [[1]](diffhunk://#diff-29f559dab117141abd8e0f78e21d9095a64d10aa3fbd987a0b58dc79364f0d03R108-R109) [[2]](diffhunk://#diff-29f559dab117141abd8e0f78e21d9095a64d10aa3fbd987a0b58dc79364f0d03L135-R152)

These changes significantly enhance the backend's AI capabilities for managers, improve test coverage and reliability, and make the system more robust and maintainable.