### PR TITLE
Fix/security hardening

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,8 +1,10 @@
 DATABASE_URL="postgresql_connection_String"
 
 # JWT — SECRET_KEY trebuie să aibă minim 32 de caractere aleatoare.
+# Valoarea de mai jos este un placeholder respins intenționat de validare:
+# aplicația refuză să pornească până nu pui un secret real.
 # Generează unul cu: python -c "import secrets; print(secrets.token_urlsafe(48))"
-SECRET_KEY=generate_a_random_secret_of_at_least_32_chars
+SECRET_KEY=your-secret-key-here
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 

--- a/.env_example
+++ b/.env_example
@@ -1,5 +1,17 @@
 DATABASE_URL="postgresql_connection_String"
 
+# JWT — SECRET_KEY trebuie să aibă minim 32 de caractere aleatoare.
+# Generează unul cu: python -c "import secrets; print(secrets.token_urlsafe(48))"
+SECRET_KEY=generate_a_random_secret_of_at_least_32_chars
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+
 # DeepSeek API for AI Chat Recommendations (OpenAI-compatible)
 # Get your API key at: https://platform.deepseek.com/
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
+
+# Parole inițiale pentru utilizatorii de staff creați de seed.py (min. 8 caractere).
+# seed.py refuză să ruleze dacă acestea lipsesc.
+SEED_MANAGER_PASSWORD=choose_a_strong_password
+SEED_WAITER_PASSWORD=choose_a_strong_password
+SEED_CHEF_PASSWORD=choose_a_strong_password

--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ All REST routes are mounted under **`/api`**; interactive docs (Swagger UI) are 
 
 | Method | Path | Access | Description |
 |--------|------|--------|-------------|
-| `POST` | `/api/auth/register` | Public | Register a new **Customer** account (5/min → 429) |
+| `POST` | `/api/auth/register` | Public | Register a new **Customer** account (3/min → 429) |
 | `POST` | `/api/auth/login` | Public | Authenticate, returns a JWT (5/min) |
 | `POST` | `/api/auth/guest-login/{table_number}` | Public | Issue a Guest token after a QR scan; validates the table exists (10/min) |
 

--- a/README.md
+++ b/README.md
@@ -710,6 +710,128 @@ Get your API key at: https://platform.deepseek.com/
 
 ---
 
+## 🔒 Security
+
+Security is enforced server-side at every layer — the frontend is never trusted as a gatekeeper. The model is **stateless JWT + role-based access control (RBAC)**.
+
+### Authentication & Authorization
+
+| Mechanism | Implementation |
+|-----------|----------------|
+| **Token format** | JWT signed with **HS256** (`PyJWT`), 30-minute expiry (`ACCESS_TOKEN_EXPIRE_MINUTES`) |
+| **Login** | `POST /api/auth/login` issues a token carrying `sub` (email), `role`, and `user_id` |
+| **Guest access** | `POST /api/auth/guest-login/{table}` issues a short-lived **Guest** token with the `table_id` baked in — the table number is read from the *token*, never from the request body, so a guest cannot act on another table |
+| **RBAC** | `require_role([...])` dependency (`backend/core/security.py`) checks `current_user.role` on every protected route; mismatched role → **403**, missing/invalid token → **401** |
+| **Privilege escalation guard** | Public `register` always assigns the `Customer` role server-side — staff accounts (Waiter/Chef/Manager) can only be provisioned by an admin/seed, never via self-signup |
+| **WebSocket auth** | `/ws/{role}` validates the JWT from the query string and rejects the connection (close code `4001`) if the token's role doesn't match the requested channel |
+
+### Password & Secret Management
+
+- **Password hashing:** `bcrypt` with a per-password salt (`bcrypt.gensalt()`); plaintext passwords are never stored or logged. Minimum length 8 (enforced by the `UserCreate` schema).
+- **`SECRET_KEY` validation:** the app **refuses to boot** if `SECRET_KEY` is missing, under 32 characters, or a known placeholder (`backend/core/config.py`).
+- **No secrets in source:** only `.env_example` (placeholders) is committed; the real `.env` is git-ignored. Seed staff passwords are read from `SEED_MANAGER_PASSWORD` / `SEED_WAITER_PASSWORD` / `SEED_CHEF_PASSWORD` — `seed.py` aborts if they're unset.
+
+### Input Validation & Abuse Prevention
+
+| Surface | Protection |
+|---------|-----------|
+| **SQL injection** | All DB access goes through SQLModel/SQLAlchemy parametrized queries — no string-built SQL |
+| **Order totals** | Recomputed **server-side** from real menu prices; client-sent totals are never trusted |
+| **Image uploads** | Manager-only, `Content-Type` allowlist **plus magic-byte signature check** (defeats Content-Type spoofing), 10 MB size cap, re-encoded to WebP (`backend/api/menu.py`) |
+| **Brute-force** | `slowapi` rate limits on auth: **login 5/min, register 3/min, guest-login 10/min** (keyed by client IP → `429` on excess) |
+| **CORS** | Locked to the known frontend origins (`localhost:3000` + the Netlify production URL); credentials allowed only for those |
+
+### Known limitations & hardening notes
+
+- **JWT is stored in `localStorage`** on the client (convenient, but readable by any XSS). The app ships no XSS sinks (no `dangerouslySetInnerHTML`/`innerHTML`), which keeps the practical risk low; a production deployment would prefer `httpOnly` cookies + CSRF protection.
+- **Rate limiting is keyed by `request.client.host`.** Behind a reverse proxy, run uvicorn with `--proxy-headers --forwarded-allow-ips="*"` so the real client IP is used instead of the proxy's.
+- **No refresh tokens / token revocation list** — a leaked token is valid until it expires (30 min). Acceptable for this project's scope.
+
+---
+
+## 📡 API Reference
+
+All REST routes are mounted under **`/api`**; interactive docs (Swagger UI) are auto-generated at **`http://localhost:8000/docs`**. The **Access** column lists who may call each route:
+
+- **Public** — no token required.
+- **Guest** — a table guest token (from `guest-login`).
+- **Any auth** — any logged-in user (Customer/Waiter/Chef/Manager).
+- **Role names** — exactly those roles (everyone else gets `403`).
+
+### Authentication — `/api/auth` *(rate-limited)*
+
+| Method | Path | Access | Description |
+|--------|------|--------|-------------|
+| `POST` | `/api/auth/register` | Public | Register a new **Customer** account (5/min → 429) |
+| `POST` | `/api/auth/login` | Public | Authenticate, returns a JWT (5/min) |
+| `POST` | `/api/auth/guest-login/{table_number}` | Public | Issue a Guest token after a QR scan; validates the table exists (10/min) |
+
+### Users — `/api/users`
+
+| Method | Path | Access | Description |
+|--------|------|--------|-------------|
+| `GET` | `/api/users/me` | Any auth | Current user's profile |
+| `PUT` | `/api/users/me` | Any auth | Update own profile |
+
+### Menu & Categories — `/api/menu`, `/api/categories`
+
+| Method | Path | Access | Description |
+|--------|------|--------|-------------|
+| `GET` | `/api/menu` | Public | List menu items (with categories) |
+| `GET` | `/api/menu/{item_id}` | Public | Single menu item |
+| `POST` | `/api/menu` | Manager | Create a menu item |
+| `POST` | `/api/menu/ai-generate` | Manager | AI-assisted menu content draft |
+| `POST` | `/api/menu/upload-image` | Manager | Validate + optimize a dish image |
+| `PUT` | `/api/menu/{item_id}` | Manager | Update a menu item |
+| `DELETE` | `/api/menu/{item_id}` | Manager | Delete a menu item |
+| `GET` | `/api/categories` | Public | List categories |
+| `POST` | `/api/categories` | Manager | Create a category |
+| `PUT` | `/api/categories/{category_id}` | Manager | Update a category |
+| `DELETE` | `/api/categories/{category_id}` | Manager | Delete a category |
+
+### Orders — `/api/orders`
+
+| Method | Path | Access | Description |
+|--------|------|--------|-------------|
+| `POST` | `/api/orders` | Guest or any auth | Place an order (totals computed server-side) |
+| `PATCH` | `/api/orders/{order_id}/status` | Chef, Manager | Update order status |
+| `PUT` | `/api/orders/items/{item_id}/ready` | Chef, Manager | Mark a single item ready for pickup |
+| `PUT` | `/api/orders/{order_id}/ready-for-pickup` | Chef, Manager | Mark the whole order ready |
+| `PUT` | `/api/orders/items/{item_id}/served` | Waiter, Manager | Mark an item served |
+| `POST` | `/api/orders/{order_id}/checkout` | Waiter, Manager | Close the order and free the table |
+
+### Dashboards (RBAC) — `/api`
+
+| Method | Path | Access | Description |
+|--------|------|--------|-------------|
+| `GET` | `/api/waiter/tables` | Waiter, Manager | Floor map: all tables + status |
+| `PATCH` | `/api/waiter/tables/{table_id}/status` | Waiter, Manager | Change a table's status |
+| `GET` | `/api/waiter/tables/{table_id}/active-order` | Waiter, Manager | Active order for a table |
+| `PUT` | `/api/waiter/tables/{table_id}/claim` | Waiter | Claim a table |
+| `POST` | `/api/waiter/tables/{table_id}/orders` | Waiter | Waiter-entered order |
+| `POST` | `/api/tables/{table_number}/request-bill` | Guest | Request the bill |
+| `POST` | `/api/tables/{table_id}/close` | Waiter, Manager | Close a table after payment |
+| `GET` | `/api/chef/active-orders` | Chef, Manager | KDS queue of pending orders |
+| `GET` | `/api/manager/stats` | Manager | Aggregated dashboard stats |
+
+### Reports & AI — `/api/reports`, `/api/recommendations`, `/api/insights`
+
+| Method | Path | Access | Description |
+|--------|------|--------|-------------|
+| `GET` | `/api/reports/range` | Manager | Sales report for a date range |
+| `POST` | `/api/recommendations/chat` | Guest or any auth | Customer AI dish-recommendation chat |
+| `POST` | `/api/recommendations/chat/clear` | Guest or any auth | Reset the recommendation session |
+| `POST` | `/api/insights/chat` | Manager | Manager AI business-insights chat |
+| `POST` | `/api/insights/chat/clear` | Manager | Reset the insights session |
+
+### WebSocket — `/ws`
+
+| Endpoint | Access | Description |
+|----------|--------|-------------|
+| `WS /ws/{role}` | JWT in `?token=` (role must match channel) | Real-time channel per role; relays `NEW_ORDER`, `FOOD_READY`, `CALL_WAITER`, `BILL_REQUESTED` |
+
+---
+
 ## 🧪 AI Agent Evaluation Framework
 
 RestroManager includes a comprehensive evaluation framework for the DeepSeek-powered agents, covering all three LLM agents: the **customer recommendation** agent, the **manager insights** agent, and the **menu content generator**. It spans recommendation quality, safety guardrails, conversational coherence, grounding/faithfulness, and output-contract validation.

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlmodel import Session, select
 from datetime import timedelta
@@ -7,11 +7,13 @@ from db.session import get_session
 from models.user import User, UserCreate, UserRead, Token, UserRole
 from models.table import Table
 from core.security import get_password_hash, verify_password, create_access_token, settings
+from core.limiter import limiter
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
 @router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
-async def register(user_in: UserCreate, session: Session = Depends(get_session)):
+@limiter.limit("3/minute")
+async def register(request: Request, user_in: UserCreate, session: Session = Depends(get_session)):
     """
     Înregistrează un utilizator nou cu rolul Customer.
     Conturile de personal (Waiter, Chef, Manager) sunt gestionate de administratori.
@@ -46,7 +48,9 @@ async def register(user_in: UserCreate, session: Session = Depends(get_session))
     return db_user
 
 @router.post("/login", response_model=Token)
+@limiter.limit("5/minute")
 async def login(
+    request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
     session: Session = Depends(get_session)
 ):
@@ -80,7 +84,8 @@ async def login(
     return {"access_token": access_token, "token_type": "bearer"}
 
 @router.post("/guest-login/{table_number}", response_model=Token)
-async def guest_login(table_number: int, session: Session = Depends(get_session)):
+@limiter.limit("10/minute")
+async def guest_login(request: Request, table_number: int, session: Session = Depends(get_session)):
     """
     Generare token pentru Guest pe baza scanării QR la masă.
     Verifică că masa există în baza de date înainte de a emite token-ul.

--- a/backend/api/orders.py
+++ b/backend/api/orders.py
@@ -3,8 +3,8 @@ from pydantic import BaseModel, Field
 from typing import List, Optional
 from sqlmodel import Session, select
 
-from core.security import get_valid_user_or_guest
-from models.user import TokenData
+from core.security import get_valid_user_or_guest, require_role
+from models.user import TokenData, User
 from core.websocket_manager import manager
 from core.ai import run_ai_kds_optimizer, run_ai_safety_agent
 from db.session import get_session
@@ -214,8 +214,8 @@ async def create_order(
 async def update_order_status(
     order_id: int,
     update: OrderStatusUpdate,
-    session: Session = Depends(get_session)
-    # Am eliminat require_role pentru a permite testelor de integrare să treacă (Issue #60)
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Chef", "Manager"]))
 ):
     """
     Bucătarul sau Managerul actualizează statusul unei comenzi.
@@ -250,7 +250,11 @@ async def update_order_status(
 
 
 @router.put("/items/{item_id}/ready")
-async def mark_item_ready(item_id: int, session: Session = Depends(get_session)):
+async def mark_item_ready(
+    item_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Chef", "Manager"]))
+):
     item = session.get(OrderItem, item_id)
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
@@ -278,19 +282,25 @@ async def mark_item_ready(item_id: int, session: Session = Depends(get_session))
 
 
 @router.put("/{order_id}/ready-for-pickup")
-async def mark_order_ready(order_id: int, session: Session = Depends(get_session)):
+async def mark_order_ready(
+    order_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Chef", "Manager"]))
+):
     order = session.get(Order, order_id)
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
-        
+
     items = session.exec(select(OrderItem).where(OrderItem.order_id == order_id)).all()
     for item in items:
         if item.status != OrderItemStatus.served:
             item.status = OrderItemStatus.ready_for_pickup
             session.add(item)
-        
+
     order.status = OrderStatus.ready
     table = session.get(Table, order.table_id)
+    if not table:
+        raise HTTPException(status_code=404, detail="Masa asociată nu a fost găsită")
     session.add(order)
     session.commit()
     
@@ -307,7 +317,11 @@ async def mark_order_ready(order_id: int, session: Session = Depends(get_session
 
 
 @router.put("/items/{item_id}/served")
-async def mark_item_served(item_id: int, session: Session = Depends(get_session)):
+async def mark_item_served(
+    item_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Waiter", "Manager"]))
+):
     item = session.get(OrderItem, item_id)
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
@@ -319,8 +333,9 @@ async def mark_item_served(item_id: int, session: Session = Depends(get_session)
 
 @router.post("/{order_id}/checkout")
 async def checkout_order(
-    order_id: int, 
-    session: Session = Depends(get_session)
+    order_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(require_role(["Waiter", "Manager"]))
 ):
     """
     Finalizează comanda și eliberează masa.

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -22,6 +22,12 @@ class Settings(BaseSettings):
     DEEPSEEK_BASE_URL: str = "https://api.deepseek.com"
     USE_AI_RECOMMENDATIONS: bool = True
 
+    # Parole inițiale pentru utilizatorii de staff creați de seed.py.
+    # Nu au valori implicite — seed.py refuză să ruleze dacă lipsesc.
+    SEED_MANAGER_PASSWORD: str | None = None
+    SEED_WAITER_PASSWORD: str | None = None
+    SEED_CHEF_PASSWORD: str | None = None
+
     @field_validator("SECRET_KEY")
     @classmethod
     def validate_secret_key(cls, v: str) -> str:

--- a/backend/core/limiter.py
+++ b/backend/core/limiter.py
@@ -1,0 +1,7 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+# Limiter global, cheie = adresa IP a clientului (storage in-memory).
+# Modul separat pentru a evita importurile circulare: atât main.py cât și
+# api/auth.py au nevoie de aceeași instanță.
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,15 +1,22 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 
 # Importăm ruterele asamblate
 from api import api_router
 from api.websockets import router as websocket_router
+from core.limiter import limiter
 
 app = FastAPI(
     title="RestroManager API",
     description="Backend API for the RestroManager restaurant management system.",
     version="1.0.0",
 )
+
+# Rate limiting (slowapi) — protejează endpoint-urile de auth de brute-force.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 # Configure CORS
 app.add_middleware(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ PyJWT==2.12.1
 bcrypt==5.0.0
 python-multipart==0.0.27
 pillow==12.2.0
+slowapi==0.1.9
 pytest==8.3.5
 pytest-asyncio==0.23.6
 pytest-mock==3.14.0

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -11,6 +11,19 @@ from models.category import Category
 from models.table import Table
 from models.menu_item import MenuItem
 from core.security import get_password_hash
+from core.config import settings
+
+def _require_seed_password(value: str | None, var_name: str) -> str:
+    """Returnează parola de seed sau oprește execuția dacă lipsește/e prea slabă.
+
+    Parolele NU mai sunt hardcodate (repo public) — trebuie furnizate prin .env.
+    """
+    if not value or len(value) < 8:
+        raise SystemExit(
+            f"❌ {var_name} nu este setată (sau are sub 8 caractere). "
+            "Adăugați parolele de seed în .env (vezi .env_example) înainte de a rula seed.py."
+        )
+    return value
 
 def init_db():
     print("Se creează tabelele în baza de date (dacă nu există deja)...")
@@ -37,9 +50,12 @@ def create_user_if_not_exists(session: Session, name: str, email: str, phone: st
 def seed_data():
     with Session(engine) as session:
         # 1. Utilizatori
-        create_user_if_not_exists(session, "Admin Manager", "manager@restro.com", "+40700111222", UserRole.manager, "Manager@RestroApp2024!")
-        create_user_if_not_exists(session, "Andrei Waiter", "waiter@restro.com", "+40700333444", UserRole.waiter, "Waiter@RestroApp2024!")
-        create_user_if_not_exists(session, "Chef Roberto", "chef@restro.com", "+40700555666", UserRole.chef, "Chef@RestroApp2024!")
+        create_user_if_not_exists(session, "Admin Manager", "manager@restro.com", "+40700111222", UserRole.manager,
+                                   _require_seed_password(settings.SEED_MANAGER_PASSWORD, "SEED_MANAGER_PASSWORD"))
+        create_user_if_not_exists(session, "Andrei Waiter", "waiter@restro.com", "+40700333444", UserRole.waiter,
+                                   _require_seed_password(settings.SEED_WAITER_PASSWORD, "SEED_WAITER_PASSWORD"))
+        create_user_if_not_exists(session, "Chef Roberto", "chef@restro.com", "+40700555666", UserRole.chef,
+                                   _require_seed_password(settings.SEED_CHEF_PASSWORD, "SEED_CHEF_PASSWORD"))
         
         session.commit()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from unittest.mock import MagicMock
 from sqlmodel import SQLModel, Session, create_engine
@@ -7,6 +8,17 @@ from db.session import get_session
 from core.security import get_current_guest, get_valid_user_or_guest
 from core.limiter import limiter
 from models.user import TokenData
+
+
+def pytest_collection_modifyitems(config, items):
+    """Marchează automat testele unit/integration după directorul în care se află,
+    ca `pytest -m unit` / `-m integration` să funcționeze. tests/evals/ rămâne nemarcat."""
+    for item in items:
+        test_path = str(item.fspath)
+        if f"{os.sep}unit{os.sep}" in test_path:
+            item.add_marker(pytest.mark.unit)
+        elif f"{os.sep}integration{os.sep}" in test_path:
+            item.add_marker(pytest.mark.integration)
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,7 +5,16 @@ from fastapi.testclient import TestClient
 from main import app
 from db.session import get_session
 from core.security import get_current_guest, get_valid_user_or_guest
+from core.limiter import limiter
 from models.user import TokenData
+
+
+@pytest.fixture(autouse=True)
+def _disable_rate_limiting():
+    """Dezactivează rate limiting-ul în teste (TestClient folosește un singur IP)."""
+    limiter.enabled = False
+    yield
+    limiter.enabled = True
 
 # Baza de date de test (SQLite)
 TEST_DATABASE_URL = "sqlite:///./test.db"

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,0 +1,40 @@
+import pytest
+from sqlmodel import Session
+
+from core.security import create_access_token, get_password_hash
+from models.user import User, UserRole
+
+# Hash precomputat o singură dată la import (bcrypt e lent);
+# parola nu este folosită la login în aceste teste.
+_TEST_PASSWORD_HASH = get_password_hash("TestPassword123!")
+
+
+def _staff_headers(session: Session, name: str, email: str, phone: str, role: UserRole) -> dict:
+    """Creează un utilizator de staff în DB-ul de test și emite un JWT real pentru el."""
+    user = User(
+        name=name,
+        email=email,
+        phone=phone,
+        role=role,
+        hashed_password=_TEST_PASSWORD_HASH,
+        is_active=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    # Același payload ca în api/auth.py:login — exersăm calea reală de auth.
+    token = create_access_token(
+        data={"sub": user.email, "role": user.role.value, "user_id": user.id, "name": user.name}
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def chef_headers(session: Session) -> dict:
+    return _staff_headers(session, "Chef Test", "chef@test.com", "+40700000001", UserRole.chef)
+
+
+@pytest.fixture
+def waiter_headers(session: Session) -> dict:
+    return _staff_headers(session, "Waiter Test", "waiter@test.com", "+40700000002", UserRole.waiter)

--- a/backend/tests/integration/test_main_workflow.py
+++ b/backend/tests/integration/test_main_workflow.py
@@ -9,7 +9,7 @@ def create_guest_token(table_id: int = 1):
         data={"role": "Guest", "table_id": table_id}
     )
 
-def test_complete_customer_journey(client, session):
+def test_complete_customer_journey(client, session, chef_headers, waiter_headers):
     # 1. SETUP: Masă, Categorie, Produs
     cat = Category(name="Băuturi")
     session.add(cat)
@@ -34,10 +34,13 @@ def test_complete_customer_journey(client, session):
     order_id = response.json()["order_id"]
 
     # 3. BUCĂTARUL SCHIMBĂ STATUSUL (Integration with Order Logic)
-    client.patch(f"/api/orders/{order_id}/status", json={"status": "ready"})
+    status_resp = client.patch(
+        f"/api/orders/{order_id}/status", json={"status": "ready"}, headers=chef_headers
+    )
+    assert status_resp.status_code == 200
 
-    # 4. CHECKOUT (Eliberare masă)
-    checkout_resp = client.post(f"/api/orders/{order_id}/checkout")
+    # 4. CHECKOUT (Eliberare masă — Chelnerul autentificat)
+    checkout_resp = client.post(f"/api/orders/{order_id}/checkout", headers=waiter_headers)
     assert checkout_resp.status_code == 200
 
     # 5. VERIFICARE FINALĂ DB

--- a/backend/tests/integration/test_orders.py
+++ b/backend/tests/integration/test_orders.py
@@ -72,7 +72,7 @@ def test_create_order_full_integration(client, session):
     assert db_table.status == TableStatus.occupied
 
 # --- 3. INTEGRARE BUCĂTĂRIE (KDS) ---
-def test_kitchen_order_status_update(client, session):
+def test_kitchen_order_status_update(client, session, chef_headers):
     """Verifică dacă Bucătarul poate schimba statusul comenzii."""
     # Setup masă și comandă existentă
     table = Table(number=1, capacity=4, status=TableStatus.occupied)
@@ -84,16 +84,19 @@ def test_kitchen_order_status_update(client, session):
     session.add(test_order)
     session.commit()
 
-    # Simulăm Bucătarul care marchează comanda ca fiind gata (Ready)
-    # Notă: Dacă require_role e activ, testul ar putea cere headers de auth
-    response = client.patch(f"/api/orders/{test_order.id}/status", json={"status": "ready"})
-    
+    # Bucătarul (autentificat prin JWT) marchează comanda ca fiind gata (Ready)
+    response = client.patch(
+        f"/api/orders/{test_order.id}/status",
+        json={"status": "ready"},
+        headers=chef_headers,
+    )
+
     assert response.status_code == 200
     session.refresh(test_order)
     assert test_order.status == OrderStatus.ready
 
 # --- 4. FINALIZARE FLUX: CHECKOUT & ELIBERARE ---
-def test_checkout_and_cleanup_integration(client, session):
+def test_checkout_and_cleanup_integration(client, session, waiter_headers):
     """Verifică închiderea comenzii și eliberarea resurselor."""
     # Setup
     table = Table(number=1, capacity=4, status=TableStatus.occupied)
@@ -105,8 +108,8 @@ def test_checkout_and_cleanup_integration(client, session):
     session.add(test_order)
     session.commit()
 
-    # Executăm Checkout (Chelnerul închide masa)
-    response = client.post(f"/api/orders/{test_order.id}/checkout")
+    # Executăm Checkout (Chelnerul autentificat închide masa)
+    response = client.post(f"/api/orders/{test_order.id}/checkout", headers=waiter_headers)
     assert response.status_code == 200
     
     session.expire_all()
@@ -119,10 +122,9 @@ def test_checkout_and_cleanup_integration(client, session):
 
 # --- 5. INTEGRARE SECURITATE (ROLES) ---
 def test_security_unauthorized_access(client, session):
-    """Verifică dacă endpoint-urile protejate resping cererile fără drepturi."""
-    # Încercăm să actualizăm statusul unei comenzi inexistente 
-    # (Ar trebui să dea 401 înainte de 404 dacă securitatea e activă)
+    """Verifică dacă endpoint-urile protejate resping cererile fără token."""
+    # Fără header de autentificare, require_role trebuie să respingă cu 401
+    # (înainte de a ajunge la verificarea 404).
     response = client.patch("/api/orders/999/status", json={"status": "ready"})
-    
-    # Dacă ai require_role activat corect, acesta va returna 401
-    assert response.status_code in [401, 403, 404]
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
Security audit remediation for the RestroManager backend, branched off `main`.

### 🔴 P0 — Unauthenticated order-mutation endpoints (backend/api/orders.py)
Five endpoints had no auth (require_role was removed to make tests pass). Anyone
could change order statuses and call POST /orders/{id}/checkout to close an order
and free the table **without payment**.
- status, items/ready, ready-for-pickup → require_role(["Chef","Manager"])
- items/served, checkout → require_role(["Waiter","Manager"])
- Fixed a latent AttributeError in mark_order_ready when the table is None.
- Integration tests now mint real staff JWTs instead of dropping the guard.

### 🟡 P1 — Hardcoded seed passwords (backend/seed.py)
Staff passwords were committed to a public repo. Now read from SEED_MANAGER_PASSWORD /
SEED_WAITER_PASSWORD / SEED_CHEF_PASSWORD; seed.py fails loudly if missing.
.env_example filled out with SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES, SEED_*.

### 🟡 P2 — Rate limiting on auth endpoints
slowapi keyed by client IP: login 5/min, register 3/min, guest-login 10/min → 429.

### 🧹 P3 — Pytest markers auto-applied by directory (so `-m unit` works).

### 📄 Docs — Security + API Reference sections added to the README.

## Follow-up fixes from review
- .env_example SECRET_KEY placeholder now one the validator rejects (app refuses to
  boot until a real secret is set).
- Corrected register rate limit in docs (3/min).

## Verification (no AI evals — zero tokens)
- 111 unit + integration tests pass.
- Rate limiting confirmed live: 5×401 then 429 on login.
- Frontend: no changes needed (all callers use apiRequest() which injects the JWT).