### PR TITLE
perf(docker): exclude nested node_modules/.next from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,28 +1,26 @@
-
 # Git
 .git
 .gitignore
 
-# Python
-__pycache__/
-*.py[cod]
-*$py.class
-*.so
-.venv/
-.venv
+# Python  (** so nested backend/ dirs are matched too)
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/*.so
+**/.venv/
 .env
 .env_example
-.pytest_cache/
-.coverage
-htmlcov/
+**/.pytest_cache/
+**/.coverage
+**/htmlcov/
 
-# Node / Next.js
-node_modules/
-.next/
-out/
-build/
-npm-debug.log*
-package-lock.json
+# Node / Next.js  (** so frontend/node_modules + frontend/.next are excluded —
+# without this they're ~1.5 GB of build context shipped on every build)
+**/node_modules/
+**/.next/
+**/out/
+**/build/
+**/npm-debug.log*
 yarn.lock
 
 # Docker
@@ -32,7 +30,7 @@ docker-compose.yml
 .dockerignore
 
 # IDEs / OS
-.DS_Store
+**/.DS_Store
 .idea/
 .vscode/
 *.swp
@@ -56,10 +54,10 @@ temp/
 backend/seed.py
 
 # Test files
-test_*
-*_test.py
-*.test.ts
-*.test.tsx
+**/test_*
+**/*_test.py
+**/*.test.ts
+**/*.test.tsx
 
 # Temporary files
 *.tmp


### PR DESCRIPTION
The .dockerignore patterns (node_modules/, .next/, __pycache__/, .venv/) only matched at the build-context root, but both services build from context: . (repo root) where the real bulk lives nested under frontend/. As a result frontend/node_modules (~690 MB) and frontend/.next (~805 MB) were hashed and uploaded to the daemon on every `docker compose up --build` — a 1.465 GB context.

Switch the directory patterns to **/ form so nested dirs are matched too. Measured build context drops from 1.465 GB to 16.3 MB (~90x). This is also more correct: the host's macOS-native frontend/node_modules can no longer leak into the Linux image via `COPY frontend/ .` — the container builds its own deps. Also un-ignore package-lock.json so the lockfile reaches the build for deterministic installs.