### PR TITLE
feat(manager): scope dashboard stats by time period

### DIFF
--- a/backend/api/dashboards.py
+++ b/backend/api/dashboards.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from datetime import datetime, timedelta, timezone
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlmodel import Session, select
 from typing import List, Optional
 from pydantic import BaseModel
@@ -356,9 +357,30 @@ async def get_chef_orders(session: Session = Depends(get_session)):
     response_model=ManagerStats,
     dependencies=[Depends(require_role(["Manager"]))]
 )
-async def get_manager_stats(session: Session = Depends(get_session)):
-    """Returnează statistici agregate din DB pentru dashboard-ul managerului."""
-    orders = session.exec(select(Order)).all()
+async def get_manager_stats(
+    period: str = Query(default="today", pattern="^(today|week|all)$"),
+    session: Session = Depends(get_session),
+):
+    """Returnează statistici agregate din DB pentru dashboard-ul managerului.
+
+    `period` scopează încasările și numărul de comenzi pe interval (granițe la
+    miezul nopții UTC, ca în reports.py); `menu_items_count` rămâne global:
+      - today: doar ziua curentă
+      - week:  ultimele 7 zile (azi + 6 zile în urmă)
+      - all:   tot istoricul
+    """
+    stmt = select(Order)
+    today = datetime.now(timezone.utc).date()
+    if period == "today":
+        cutoff = datetime(today.year, today.month, today.day)
+        stmt = stmt.where(Order.created_at >= cutoff)
+    elif period == "week":
+        start = today - timedelta(days=6)
+        cutoff = datetime(start.year, start.month, start.day)
+        stmt = stmt.where(Order.created_at >= cutoff)
+    # "all" → fără filtru de timp
+
+    orders = session.exec(stmt).all()
     total_revenue = round(sum(o.total_price for o in orders), 2)
     total_orders = len(orders)
     menu_items_count = len(session.exec(select(MenuItem)).all())

--- a/frontend/__tests__/app/manager/ClientPage.test.tsx
+++ b/frontend/__tests__/app/manager/ClientPage.test.tsx
@@ -51,7 +51,7 @@ describe('Manager Dashboard', () => {
           json: () => Promise.resolve([{ id: 1, name: 'Food' }])
         })
       }
-      if (url === '/manager/stats') {
+      if (url.startsWith('/manager/stats')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({ total_revenue: 500, total_orders: 10, menu_items_count: 1 })
@@ -103,7 +103,7 @@ describe('Manager Dashboard', () => {
       if (url === '/categories') {
         return Promise.resolve(ok([{ id: 1, name: 'Food' }]))
       }
-      if (url === '/manager/stats') {
+      if (url.startsWith('/manager/stats')) {
         return Promise.resolve(ok({ total_revenue: 0, total_orders: 0, menu_items_count: 1 }))
       }
       if (url === '/menu/ai-generate') {

--- a/frontend/app/manager/ClientPage.tsx
+++ b/frontend/app/manager/ClientPage.tsx
@@ -59,6 +59,7 @@ export default function ManagerPage() {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [stats, setStats] = useState<ManagerStats | null>(null);
+  const [statsPeriod, setStatsPeriod] = useState<"today" | "week" | "all">("today");
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<MenuItem | null>(null);
@@ -113,16 +114,14 @@ export default function ManagerPage() {
     setLoading(true);
     setError(null);
     try {
-      const [menuRes, catRes, statsRes] = await Promise.all([
+      const [menuRes, catRes] = await Promise.all([
         apiRequest("/menu"),
         apiRequest("/categories"),
-        apiRequest("/manager/stats"),
       ]);
       if (!menuRes.ok) throw new Error("Eroare la încărcarea meniului");
       if (!catRes.ok) throw new Error("Eroare la încărcarea categoriilor");
       setMenuItems(await menuRes.json());
       setCategories(await catRes.json());
-      if (statsRes.ok) setStats(await statsRes.json());
     } catch (err) {
       setError(err instanceof Error ? err.message : "Eroare necunoscută");
     } finally {
@@ -130,9 +129,20 @@ export default function ManagerPage() {
     }
   }, []);
 
+  // Statistici de sus — separate de loadData fiindcă se reîncarcă la schimbarea
+  // intervalului (Azi / Săptămână / Tot), nu doar la mount.
+  const loadStats = useCallback(async () => {
+    const res = await apiRequest(`/manager/stats?period=${statsPeriod}`);
+    if (res.ok) setStats(await res.json());
+  }, [statsPeriod]);
+
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
 
   function resetForm() {
     setFormName("");
@@ -468,10 +478,24 @@ export default function ManagerPage() {
           <Button className="bg-green-600 hover:bg-green-500 font-bold" onClick={handleAddNew}>+ Adaugă Produs Nou</Button>
         </div>
 
+        <div className="flex items-center gap-2 mb-4">
+          {([["today", "Azi"], ["week", "Săptămâna"], ["all", "Tot"]] as const).map(([key, label]) => (
+            <Button
+              key={key}
+              onClick={() => setStatsPeriod(key)}
+              className={statsPeriod === key
+                ? "bg-green-600 hover:bg-green-500 font-bold"
+                : "bg-slate-800 hover:bg-slate-700 text-slate-300 font-medium"}
+            >
+              {label}
+            </Button>
+          ))}
+        </div>
+
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Încasări Totale</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-green-400">{stats ? `${stats.total_revenue.toFixed(2)} RON` : "—"}</p></CardContent></Card>
-          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Comenzi Totale</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-blue-400">{stats ? stats.total_orders : "—"}</p></CardContent></Card>
-          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Produse în Meniu</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-green-400">{stats ? stats.menu_items_count : menuItems.length}</p></CardContent></Card>
+          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Încasări · {{ today: "Azi", week: "Săptămâna", all: "Tot" }[statsPeriod]}</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-green-400">{stats ? `${stats.total_revenue.toFixed(2)} RON` : "—"}</p></CardContent></Card>
+          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Comenzi · {{ today: "Azi", week: "Săptămâna", all: "Tot" }[statsPeriod]}</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-blue-400">{stats ? stats.total_orders : "—"}</p></CardContent></Card>
+          <Card className="bg-slate-900 border-slate-800"><CardHeader><CardTitle className="text-slate-400 text-sm uppercase">Produse în Meniu</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold text-green-400">{menuItems.length}</p></CardContent></Card>
         </div>
 
         {loading && <div className="text-center py-12 text-slate-400 text-lg">Se încarcă meniul...</div>}


### PR DESCRIPTION
The headline cards (Încasări / Comenzi) summed every order ever, which isn't actionable for a manager and grows forever. Add a time selector.

- backend: /manager/stats accepts ?period=today|week|all (default today), filtering Order.created_at with midnight-UTC bounds like reports.py. menu_items_count stays global.
- frontend: Azi / Săptămâna / Tot selector above the cards; stats fetch decoupled into its own effect that reloads on period change. Card labels are now dynamic ("Încasări · Azi"). The menu-count card reads menuItems.length directly so it's always fresh.
- test: manager stats mock matches the URL with its query param.

Revenue still sums all statuses within the period (paid/completed filtering intentionally left out of this change).