### PR TITLE
Fix/waiter order refresh after add

### DIFF
--- a/frontend/app/waiter/ClientPage.tsx
+++ b/frontend/app/waiter/ClientPage.tsx
@@ -125,7 +125,6 @@ function WaiterContent() {
         })
       });
       if (res.ok) {
-        const orderData = await res.json();
         setCart({});
         setIsMenuMode(false);
         // Refresh tables and update selectedTable to get new waiter_id and status
@@ -134,8 +133,13 @@ function WaiterContent() {
         if (updatedTable) {
           setSelectedTable(updatedTable);
         }
-        // Set the newly created order as active
-        setActiveOrder(orderData);
+        // Re-fetch the full active order: POST /orders only returns the items just
+        // added, so we'd otherwise drop items already on the order until a manual
+        // refresh. This endpoint returns every item of the active order.
+        const orderRes = await apiRequest(`/waiter/tables/${selectedTable.id}/active-order`);
+        if (orderRes.ok) {
+          setActiveOrder(await orderRes.json());
+        }
       } else {
         const error = await res.json();
         console.error("Eroare la crearea comenzii:", error);

--- a/frontend/app/waiter/ClientPage.tsx
+++ b/frontend/app/waiter/ClientPage.tsx
@@ -366,17 +366,23 @@ function WaiterContent() {
                     <h3 className="font-black text-slate-200 uppercase mb-4 text-sm tracking-wider border-b border-slate-700 pb-2">{category as string}</h3>
                     <div className="space-y-3">
                       {menuItems.filter(i => i.category === category).map(item => (
-                        <div key={item.id} className="flex justify-between items-center bg-slate-800 p-3 rounded-xl border border-slate-700">
+                        <div key={item.id} className={`flex justify-between items-center p-3 rounded-xl border ${item.is_available ? "bg-slate-800 border-slate-700" : "bg-slate-800/40 border-slate-800 opacity-60"}`}>
                           <div>
                             <p className="font-bold text-slate-100">{item.name}</p>
                             <p className="text-sm font-bold text-green-400">{item.price} Lei</p>
                           </div>
-                          <button 
-                            onClick={() => setItemToAdd(item)}
-                            className="bg-blue-600 hover:bg-blue-500 text-white font-bold px-4 py-2 rounded-full transition-colors text-sm shrink-0"
-                          >
-                            Adaugă
-                          </button>
+                          {item.is_available ? (
+                            <button
+                              onClick={() => setItemToAdd(item)}
+                              className="bg-blue-600 hover:bg-blue-500 text-white font-bold px-4 py-2 rounded-full transition-colors text-sm shrink-0"
+                            >
+                              Adaugă
+                            </button>
+                          ) : (
+                            <span className="text-[10px] bg-red-950/40 text-red-400 border border-red-800 font-bold px-3 py-1.5 rounded-full uppercase shrink-0">
+                              Indisponibil
+                            </span>
+                          )}
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
This pull request improves the waiter client page by ensuring the active order is accurately updated after adding items and by enhancing the menu UI to clearly indicate item availability.

Order management improvements:

* After creating an order, the code now re-fetches the full active order using the `/waiter/tables/{id}/active-order` endpoint, ensuring all items (including previously added ones) are shown, preventing temporary data loss until manual refresh. [[1]](diffhunk://#diff-5eedee7b8fe78a92af410a6be2fce3216e0cd59311e534cba0627d1846f3033eL128) [[2]](diffhunk://#diff-5eedee7b8fe78a92af410a6be2fce3216e0cd59311e534cba0627d1846f3033eL137-R142)

Menu UI enhancements:

* Menu items that are not available are now visually distinguished with reduced opacity and a clear "Indisponibil" badge, and the "Adaugă" button is hidden for those items, improving user experience and preventing unavailable items from being added.